### PR TITLE
RVFI fix and SVA perf fix

### DIFF
--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -605,8 +605,8 @@ module cv32e40s_rvfi
 
   assign rvfi_csr_rdata_d.mhpmevent          = csr_mhpmevent_q_i;
   assign rvfi_csr_wdata_d.mhpmevent          = csr_mhpmevent_n_i;
-  assign rvfi_csr_mhpmevent_wmask[2:0]       = '0; // No mhpevent0-2 registers
-  assign rvfi_csr_mhpmevent_wmask[31:3]      = csr_mhpmevent_we_i ? '1 : '0;
+  assign rvfi_csr_wmask_d.mhpmevent[2:0]     = '0; // No mhpevent0-2 registers
+  assign rvfi_csr_wmask_d.mhpmevent[31:3]    = csr_mhpmevent_we_i ? '1 : '0;
 
   // Machine trap handling
   assign rvfi_csr_rdata_d.mscratch           = csr_mscratch_q_i;

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -268,7 +268,7 @@ always_ff @(posedge clk , negedge rst_ni)
   // before entering debug mode
   a_single_step_with_irq :
     assert property (@(posedge clk) disable iff (!rst_ni)
-                      (inst_taken && debug_single_step && !ctrl_fsm.debug_mode && interrupt_taken) [->1:2]
+                      (inst_taken && debug_single_step && !ctrl_fsm.debug_mode && interrupt_taken) [*1:2]
                       ##1 inst_taken [->1]
                       |-> (ctrl_fsm.debug_mode && debug_single_step))
       else `uvm_error("core", "Assertion a_single_step_with_irq failed")


### PR DESCRIPTION
Similar fixes were applied to the CV32E40X
Enables core to run under Questa and DSIM.
