### PR TITLE
set MISA bit [20] for user mode supported

### DIFF
--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -103,7 +103,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 | (32'(1)                               << 12)  // M - Integer Multiply/Divide extension
 | (32'(0)                               << 13)  // N - User level interrupts supported
 | (32'(0)                               << 18)  // S - Supervisor mode implemented
-| (32'(0)                               << 20)  // U - User mode implemented
+| (32'(1)                               << 20)  // U - User mode implemented
 | (32'(0)                          << 23)  // X - Non-standard extensions present
 | (32'(MXL)                        << 30); // M-XLEN
 


### PR DESCRIPTION
this will enable using the Imperas OVPSIM cv32e40s variant - user mode can not be disabled on the model so we must match the CSR setting

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>