### PR TITLE
Make PMP parameters int (not unsigned) to avoid simulators crashing o…

### DIFF
--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -32,8 +32,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
 #(
   parameter NUM_MHPMCOUNTERS             =  1,
   parameter LIB                          =  0,
-  parameter int unsigned PMP_GRANULARITY =  0,
-  parameter int unsigned PMP_NUM_REGIONS =  0,
+  parameter int PMP_GRANULARITY =  0,
+  parameter int PMP_NUM_REGIONS =  0,
   parameter b_ext_e B_EXT                =  NONE,
   parameter int unsigned PMA_NUM_REGIONS =  0,
   parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT}

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -35,8 +35,8 @@
 module cv32e40s_cs_registers import cv32e40s_pkg::*;
 #(
   parameter A_EXTENSION      = 0,
-  parameter PMP_NUM_REGIONS  = 0,
-  parameter PMP_GRANULARITY  = 0,
+  parameter int PMP_NUM_REGIONS  = 0,
+  parameter int PMP_GRANULARITY  = 0,
   parameter NUM_MHPMCOUNTERS = 1
 )
 (

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -27,8 +27,8 @@
 
 module cv32e40s_if_stage import cv32e40s_pkg::*;
   #(parameter bit          A_EXTENSION     = 0,
-    parameter int unsigned PMP_GRANULARITY = 0,
-    parameter int unsigned PMP_NUM_REGIONS = 0,
+    parameter int          PMP_GRANULARITY = 0,
+    parameter int          PMP_NUM_REGIONS = 0,
     parameter int unsigned PMA_NUM_REGIONS = 0,
     parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT})
 (

--- a/rtl/cv32e40s_load_store_unit.sv
+++ b/rtl/cv32e40s_load_store_unit.sv
@@ -26,8 +26,8 @@
 
 module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   #(parameter bit          A_EXTENSION = 0,
-    parameter int unsigned PMP_GRANULARITY = 0,
-    parameter int unsigned PMP_NUM_REGIONS = 0,
+    parameter int          PMP_GRANULARITY = 0,
+    parameter int          PMP_NUM_REGIONS = 0,
     parameter int unsigned PMA_NUM_REGIONS = 0,
                            parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT})
 (

--- a/rtl/cv32e40s_mpu.sv
+++ b/rtl/cv32e40s_mpu.sv
@@ -29,8 +29,8 @@ module cv32e40s_mpu import cv32e40s_pkg::*;
       parameter type         CORE_REQ_TYPE                = obi_inst_req_t,
       parameter type         CORE_RESP_TYPE               = inst_resp_t,
       parameter type         BUS_RESP_TYPE                = obi_inst_resp_t,
-      parameter int unsigned PMP_GRANULARITY              = 0,
-      parameter int unsigned PMP_NUM_REGIONS              = 0,
+      parameter int          PMP_GRANULARITY              = 0,
+      parameter int          PMP_NUM_REGIONS              = 0,
       parameter int unsigned PMA_NUM_REGIONS              = 0,
       parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT})
   (

--- a/rtl/cv32e40s_pmp.sv
+++ b/rtl/cv32e40s_pmp.sv
@@ -32,9 +32,9 @@ module cv32e40s_pmp import cv32e40s_pkg::*;
   #(
     // Granularity of NAPOT access,
     // 0 = No restriction, 1 = 8 byte, 2 = 16 byte, 3 = 32 byte, etc.
-    parameter int unsigned PMP_GRANULARITY = 0,
+    parameter int PMP_GRANULARITY = 0,
     // Number of implemented regions
-    parameter int unsigned PMP_NUM_REGIONS = 0
+    parameter int PMP_NUM_REGIONS = 0
     )
   (
    // Clock and Reset


### PR DESCRIPTION
Not able to verify on dsim, but experiments show that this fixes the issue for Synopsys VCS.
The idea is that -1 becomes a very large number when interpreted as an unsigned int, but should be fine when interpreted as int.