### PR TITLE
mret and wfi in User mode

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -171,7 +171,9 @@ module cv32e40s_wrapper
                               .csr_we_i            (core_i.cs_registers_i.csr_we_int  ),
                               .mstatus_i           (core_i.mstatus),
                               .current_priv_lvl_i  (core_i.cs_registers_i.priv_lvl_o),
+                              .priv_lvl_n          (core_i.cs_registers_i.priv_lvl_n),
                               .wfi_insn_id_i       (core_i.id_stage_i.wfi_insn),
+                              .id_valid_i          (core_i.id_stage_i.id_valid),
                               .*);
   bind cv32e40s_cs_registers:        core_i.cs_registers_i              cv32e40s_cs_registers_sva cs_registers_sva (.*);
 

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -173,6 +173,7 @@ module cv32e40s_wrapper
                               .current_priv_lvl_i  (core_i.cs_registers_i.priv_lvl_o),
                               .priv_lvl_n          (core_i.cs_registers_i.priv_lvl_n),
                               .wfi_insn_id_i       (core_i.id_stage_i.wfi_insn),
+                              .mret_insn_id_i      (core_i.id_stage_i.mret_insn),
                               .id_valid_i          (core_i.id_stage_i.id_valid),
                               .*);
   bind cv32e40s_cs_registers:        core_i.cs_registers_i              cv32e40s_cs_registers_sva cs_registers_sva (.*);

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -169,6 +169,9 @@ module cv32e40s_wrapper
                               .lsu_outstanding_cnt (core_i.load_store_unit_i.cnt_q),
                               .rf_we_wb_i          (core_i.wb_stage_i.rf_we_wb_o  ),
                               .csr_we_i            (core_i.cs_registers_i.csr_we_int  ),
+                              .mstatus_i           (core_i.mstatus),
+                              .current_priv_lvl_i  (core_i.cs_registers_i.priv_lvl_o),
+                              .wfi_insn_id_i       (core_i.id_stage_i.wfi_insn),
                               .*);
   bind cv32e40s_cs_registers:        core_i.cs_registers_i              cv32e40s_cs_registers_sva cs_registers_sva (.*);
 

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -45,6 +45,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   input  logic        dret_id_i,
   input  logic        csr_en_id_i,
   input  csr_opcode_e csr_op_id_i,
+  input  logic        wfi_id_i,
 
   input  id_ex_pipe_t id_ex_pipe_i,
   input  ex_wb_pipe_t ex_wb_pipe_i,
@@ -177,6 +178,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     .csr_en_id_i                ( csr_en_id_i              ),
     .csr_op_id_i                ( csr_op_id_i              ),
     .debug_trigger_match_id_i   ( debug_trigger_match_id_i ),
+    .wfi_id_i                   ( wfi_id_i                 ),
 
     // From EX
     .csr_raddr_ex_i             ( csr_raddr_ex_i           ),

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -49,6 +49,7 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   input  logic        dret_id_i,                  // dret in ID
   input  logic        csr_en_id_i,                // CSR in ID
   input  csr_opcode_e csr_op_id_i,                // CSR opcode (ID)
+  input  logic        wfi_id_i,                   // WFI instruction in ID
 
   // From cs_registers
   input  logic        debug_trigger_match_id_i,         // Trigger match in ID
@@ -111,13 +112,13 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   //TODO:OK:low This CSR stall check is very restrictive
   //         Should only check EX vs WB, and also CSR/rd addr
   //         Also consider whether ID or EX should be stalled
-  // Detect when a CSR insn is in ID
+  // Detect when a CSR insn is in ID (including WFI which reads mstatus.tw and priv level)
   // Note that hazard detection uses the registered instr_valid signals. Usage of the local
   // instr_valid signals would lead to a combinatorial loop via the halt signal.
 
   // todo:low:Above loop reasoning only applies to halt_id; for other pipeline stages a local instr_valid signal can maybe be used.
 
-  assign csr_read_in_id = (csr_en_id_i || mret_id_i) && if_id_pipe_i.instr_valid;
+  assign csr_read_in_id = (csr_en_id_i || mret_id_i || wfi_id_i) && if_id_pipe_i.instr_valid;
 
   // Detect when a CSR insn  in in EX or WB
   // mret and dret implicitly writes to CSR. (dret is killing IF/ID/EX once it

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -162,6 +162,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
   PrivLvl_t    current_priv_lvl, current_priv_lvl_lsu;
 
+  Status_t     mstatus;
+
   // LSU
   logic        lsu_split_ex;
   mpu_status_e lsu_mpu_status_wb;
@@ -427,6 +429,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     // CSR ID/EX
     .current_priv_lvl_i           ( current_priv_lvl          ),
+    .mstatus_i                    ( mstatus                   ),
 
     // Debug Signals
     .debug_trigger_match_id_i     ( debug_trigger_match_id    ),       // from cs_registers (ID timing)
@@ -656,6 +659,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .mip_i                      ( mip                    ),
     .m_irq_enable_o             ( m_irq_enable           ),
     .mepc_o                     ( mepc                   ),
+    .mstatus_o                  ( mstatus                ),
  
     // PMP CSR's    
     .csr_pmp_o                  ( csr_pmp                ),

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -212,6 +212,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   // Controller <-> decoder 
   logic       mret_insn_id;
   logic       dret_insn_id;
+  logic       wfi_insn_id;
   logic [1:0] ctrl_transfer_insn_id;
   logic [1:0] ctrl_transfer_insn_raw_id;
  
@@ -440,6 +441,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     .mret_insn_o                  ( mret_insn_id              ),
     .dret_insn_o                  ( dret_insn_id              ),
+    .wfi_insn_o                   ( wfi_insn_id               ),
 
     .csr_en_o                     ( csr_en_id                 ),
     .csr_op_o                     ( csr_op_id                 ),
@@ -707,6 +709,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .dret_id_i                      ( dret_insn_id           ),
     .csr_en_id_i                    ( csr_en_id              ),
     .csr_op_id_i                    ( csr_op_id              ),
+    .wfi_id_i                       ( wfi_insn_id            ),
                                                                  
     // LSU
     .lsu_split_ex_i                 ( lsu_split_ex           ),

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -93,6 +93,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   output PrivLvl_t        priv_lvl_o,
   output PrivLvl_t        priv_lvl_lsu_o,
 
+  output Status_t         mstatus_o,
+
   input  logic [31:0]     pc_if_i
 );
   
@@ -812,6 +814,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   assign m_irq_enable_o  = mstatus_q.mie && !(dcsr_q.step && !dcsr_q.stepie);
   assign priv_lvl_o      = priv_lvl_q;
   assign priv_lvl_lsu_o  = mstatus_q.mprv ? PrivLvl_t'(mstatus_q.mpp) : priv_lvl_q;
+
+  assign mstatus_o       = mstatus_q;
 
   assign mtvec_addr_o    = mtvec_q.addr;
   assign mtvec_mode_o    = mtvec_q.mode;

--- a/rtl/cv32e40s_decoder.sv
+++ b/rtl/cv32e40s_decoder.sv
@@ -77,6 +77,7 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
   output logic        csr_en_o,                 // enable access to CSR
   output csr_opcode_e csr_op_o,                 // operation to perform on CSR
   input  PrivLvl_t    current_priv_lvl_i,       // The current privilege level // todo:AB:low proper name
+  input  Status_t     mstatus_i,                // Current mstatus
 
   // LSU
   output logic        lsu_en_o,                 // start transaction to data memory
@@ -118,6 +119,8 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
     i_decoder_i
       (.instr_rdata_i(instr_rdata_i),
        .ctrl_fsm_i (ctrl_fsm_i),
+       .current_priv_lvl_i (current_priv_lvl_i),
+       .mstatus_i (mstatus_i),
        .decoder_ctrl_o(decoder_i_ctrl));
   
   // RV32M extension decoder

--- a/rtl/cv32e40s_i_decoder.sv
+++ b/rtl/cv32e40s_i_decoder.sv
@@ -312,7 +312,7 @@ module cv32e40s_i_decoder import cv32e40s_pkg::*;
 
               12'h302:  // mret
               begin
-                // Mret will be stalled for any CSR writes in either EX or WB,
+                // Mret will be stalled for any CSR writes (including priv level changes) in either EX or WB,
                 // curent priv_lvl from cs_registers may be used
                 if (current_priv_lvl_i != PRIV_LVL_M) begin
                   decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
@@ -340,6 +340,8 @@ module cv32e40s_i_decoder import cv32e40s_pkg::*;
                 // sleeping when not allowed to.
                 // If in user mode, WFI is treated like an illegal instruction
                 // if mstatus.tw == 1
+                // WFI in ID is stalled if CSR writes (including priv level) is present in EX or WB.
+                // - Safe to use current_priv_lvl_i and mstatus_i.tw
                 if((current_priv_lvl_i == PRIV_LVL_U) && mstatus_i.tw) begin
                   decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
                 end else begin

--- a/rtl/cv32e40s_i_decoder.sv
+++ b/rtl/cv32e40s_i_decoder.sv
@@ -34,7 +34,9 @@ module cv32e40s_i_decoder import cv32e40s_pkg::*;
    // from IF/ID pipeline
    input logic [31:0] instr_rdata_i,
 
-   input  ctrl_fsm_t     ctrl_fsm_i, // todo:low each use of this signal needs a comment explaining why the signal from the controller is safe to be used with ID timing (probably add comment in FSM)
+   input  ctrl_fsm_t     ctrl_fsm_i,         // todo:low each use of this signal needs a comment explaining why the signal from the controller is safe to be used with ID timing (probably add comment in FSM)
+   input  PrivLvl_t      current_priv_lvl_i, // current priviledge level
+   input  Status_t       mstatus_i,
    output decoder_ctrl_t decoder_ctrl_o
    );
   
@@ -310,7 +312,13 @@ module cv32e40s_i_decoder import cv32e40s_pkg::*;
 
               12'h302:  // mret
               begin
-                decoder_ctrl_o.mret_insn = 1'b1;
+                // Mret will be stalled for any CSR writes in either EX or WB,
+                // curent priv_lvl from cs_registers may be used
+                if (current_priv_lvl_i != PRIV_LVL_M) begin
+                  decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+                end else begin
+                  decoder_ctrl_o.mret_insn = 1'b1;
+                end
               end
 
               12'h7b2:  // dret
@@ -330,10 +338,16 @@ module cv32e40s_i_decoder import cv32e40s_pkg::*;
                 // keep rf_we = 0, rf_re[0] = 0
                 // Suppressing wfi_insn bit in case of ctrl_fsm_i.debug_wfi_no_sleep to prevent
                 // sleeping when not allowed to.
-                decoder_ctrl_o.wfi_insn = ctrl_fsm_i.debug_wfi_no_sleep ? 1'b0 : 1'b1;
-                decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
-                decoder_ctrl_o.imm_b_mux_sel    = IMMB_I;
-                decoder_ctrl_o.alu_operator     = ALU_ADD;
+                // If in user mode, WFI is treated like an illegal instruction
+                // if mstatus.tw == 1
+                if((current_priv_lvl_i == PRIV_LVL_U) && mstatus_i.tw) begin
+                  decoder_ctrl_o = DECODER_CTRL_ILLEGAL_INSN;
+                end else begin
+                  decoder_ctrl_o.wfi_insn = ctrl_fsm_i.debug_wfi_no_sleep ? 1'b0 : 1'b1;
+                  decoder_ctrl_o.alu_op_b_mux_sel = OP_B_IMM;
+                  decoder_ctrl_o.imm_b_mux_sel    = IMMB_I;
+                  decoder_ctrl_o.alu_operator     = ALU_ADD;
+                end
               end
 
               default:

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -70,6 +70,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
   output logic        mret_insn_o,
   output logic        dret_insn_o,
+  output logic        wfi_insn_o,
   // Decoder to controller
   output logic        csr_en_o,
   output csr_opcode_e csr_op_o,
@@ -190,6 +191,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
   assign mret_insn_o = mret_insn;
   assign dret_insn_o = dret_insn;
+  assign wfi_insn_o  = wfi_insn;
 
   assign instr = if_id_pipe_i.instr.bus_resp.rdata;
 

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -57,6 +57,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   input  ctrl_fsm_t   ctrl_fsm_i,
 
   input  PrivLvl_t    current_priv_lvl_i,
+  input  Status_t     mstatus_i,
 
   // Debug Signal
   input  logic        debug_trigger_match_id_i,
@@ -399,6 +400,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
     .csr_en_o                        ( csr_en                    ),
     .csr_op_o                        ( csr_op                    ),
     .current_priv_lvl_i              ( current_priv_lvl_i        ),
+    .mstatus_i                       ( mstatus_i                 ),
 
     // LSU interface
     .lsu_en_o                        ( lsu_en                    ),

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -65,6 +65,7 @@ module cv32e40s_controller_fsm_sva
   input PrivLvl_t       priv_lvl_n,
   input Status_t        mstatus_i,
   input logic           wfi_insn_id_i,
+  input logic           mret_insn_id_i,
   input logic [7:0]     exception_cause_wb,
   input logic           exception_in_wb
 );
@@ -244,27 +245,30 @@ module cv32e40s_controller_fsm_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                      fencei_flush_req_o |-> fencei_ready)
       else `uvm_error("controller", "Fencei handshake active while fencei_ready = 0")
-    
-  // Check that a mstatus.tw is not written from WB while U-mode WFI is in ID
-  a_wfi_id_tw :
-    assert property (@(posedge clk) disable iff (!rst_n)
-                      (wfi_insn_id_i && if_id_pipe_i.instr_valid && (current_priv_lvl_i == PRIV_LVL_U))
-                      |=> !$changed(mstatus_i.tw))
-      else `uvm_error("controller", "mstatus.tw written while WFI in user-mode is in ID")
 
-  // Check that a mstatus.tw is not written from WB while U-mode WFI is in EX
-  a_wfi_ex_tw :
+  // Helper logic to make assertion look cleaner
+  // Same logic as in the bypass module, but duplicated here to catch any changes in bypass
+  // that could lead to undetected errors
+  logic csrw_ex_wb;
+  assign csrw_ex_wb = (
+                        ((id_ex_pipe_i.csr_en || id_ex_pipe_i.mret_insn) && id_ex_pipe_i.instr_valid) ||
+                        ((ex_wb_pipe_i.csr_en || ex_wb_pipe_i.mret_insn) && ex_wb_pipe_i.instr_valid)
+                      );
+  // Check that WFI is stalled in ID if CSR writes (explicit and implicit)
+  // are present in EX or WB
+  a_wfi_id_halt :
     assert property (@(posedge clk) disable iff (!rst_n)
-                      (id_ex_pipe_i.wfi_insn && id_ex_pipe_i.instr_valid && (current_priv_lvl_i == PRIV_LVL_U))
-                      |=> !$changed(mstatus_i.tw))
-      else `uvm_error("controller", "mstatus.tw written while WFI in user-mode is in EX")
+                      (wfi_insn_id_i && if_id_pipe_i.instr_valid && csrw_ex_wb)
+                      |-> (!id_valid_i && ctrl_fsm_o.halt_id))
+      else `uvm_error("controller", "WFI not halted in ID when CSR write is present in EX or WB")
 
-  // Check that priv level is not changed when WFI is in ID
-  a_wfi_id_priv :
+  // Check that mret is stalled in ID if CSR writes (explicit and implicit)
+  // are present in EX or WB
+  a_mret_id_halt :
     assert property (@(posedge clk) disable iff (!rst_n)
-                      (wfi_insn_id_i && if_id_pipe_i.instr_valid && id_valid_i)
-                      |-> (current_priv_lvl_i == priv_lvl_n))
-      else `uvm_error("controller", "Priviledge level changed while WFI valid out of ID")
+                      (mret_insn_id_i && if_id_pipe_i.instr_valid && csrw_ex_wb)
+                      |-> (!id_valid_i && ctrl_fsm_o.halt_id))
+      else `uvm_error("controller", "mret not halted in ID when CSR write is present in EX or WB")
 
   // mret in User mode must result in illegal instruction
   a_mret_umode :
@@ -275,6 +279,16 @@ module cv32e40s_controller_fsm_sva
                       ((ex_wb_pipe_i.instr.bus_resp.rdata == 32'h30200073) && ex_wb_pipe_i.instr_valid && (current_priv_lvl_i == PRIV_LVL_U))
                       |-> (exception_in_wb && (exception_cause_wb == EXC_CAUSE_ILLEGAL_INSN) && !ex_wb_pipe_i.mret_insn))
       else `uvm_error("controller", "mret in U-mode not flagged as illegal")
+
+  // mret in machine mode must not result in illegal instruction
+  a_mret_mmode :
+    assert property (@(posedge clk) disable iff (!rst_n)
+                      // Disregard higher priority exceptions and trigger match
+                      !(((ex_wb_pipe_i.instr.mpu_status != MPU_OK) || ex_wb_pipe_i.instr.bus_resp.err || trigger_match_in_wb) && ex_wb_pipe_i.instr_valid) &&
+                      // Check for mret in instruction word and user mode
+                      ((ex_wb_pipe_i.instr.bus_resp.rdata == 32'h30200073) && ex_wb_pipe_i.instr_valid && (current_priv_lvl_i == PRIV_LVL_M))
+                      |-> (!exception_in_wb && ex_wb_pipe_i.mret_insn))
+      else `uvm_error("controller", "mret in M-mode flagged as illegal")
 
   // WFI in User mode with mstatus.tw==1 must result in illegal instruction
   a_wfi_tw_set_umode :

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -114,6 +114,7 @@ always_ff @(posedge clk , negedge rst_ni)
         first_illegal_found   <= 1'b1;
         expected_illegal_mepc <= ex_wb_pipe.pc;
       end
+      // todo: must check for M/U-mode as well, otherwise this will pick up both types of Ecalls
       if (!first_ecall_found && ex_wb_pipe.instr_valid && !irq_ack_o && !(ctrl_pending_debug && ctrl_debug_allowed) &&
         !(ex_wb_pipe.instr.bus_resp.err || (ex_wb_pipe.instr.mpu_status != MPU_OK) || ex_wb_pipe.illegal_insn) &&
         !(ctrl_fsm.exc_pc_mux == EXC_PC_NMI) &&

--- a/sva/cv32e40s_ex_stage_sva.sv
+++ b/sva/cv32e40s_ex_stage_sva.sv
@@ -61,4 +61,6 @@ a_split_rf_we:
   assert property (@(posedge clk) disable iff (!rst_n)
                     (ex_valid_o && wb_ready_i && id_ex_pipe_i.lsu_en && lsu_split_i)
                     |=> !ex_wb_pipe_o.rf_we);
+
+
 endmodule // cv32e40s_ex_stage_sva

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -48,7 +48,9 @@ module cv32e40s_id_stage_sva
   input id_ex_pipe_t    id_ex_pipe_o,
   input logic           id_ready_o,
   input logic           id_valid,
-  input ctrl_fsm_t      ctrl_fsm_i
+  input ctrl_fsm_t      ctrl_fsm_i,
+  input PrivLvl_t       current_priv_lvl_i,
+  input Status_t        mstatus_i
 );
 
 


### PR DESCRIPTION
mret during user mode will result in illegal instruction.
WFI during user mode will result in illegal instruction if mstatus.tw == 1.

Added stalling of IF stage if WFI is present and CSR writes (including priv lvl updates via mret) is present in EX or WB.