### PR TITLE
Dummy instruction fixes

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -158,10 +158,7 @@ module cv32e40s_wrapper
       bind cv32e40s_dummy_instr :
         core_i.if_stage_i.gen_dummy_instr.dummy_instr_i cv32e40s_dummy_instr_sva
       dummy_instr_sva
-        (.cpuctrl_we     (core_i.cs_registers_i.cpuctrl_we),
-         .cpuctrl_n      (core_i.cs_registers_i.cpuctrl_n),
-         .secureseed0_we (core_i.cs_registers_i.secureseed0_we),
-         .secureseed0_n  (core_i.cs_registers_i.secureseed0_n),
+        (
          .*
          );
     end

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -88,6 +88,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
 
   // CSR write stobes
   input logic          cpuctrl_wr_in_wb_i,
+  input logic          secureseed_wr_in_wb_i,
 
   input logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_id_i,
   input rf_addr_t     rf_raddr_id_i[REGFILE_NUM_READ_PORTS],
@@ -162,6 +163,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
 
     // CSR write strobes
     .cpuctrl_wr_in_wb_i          ( cpuctrl_wr_in_wb_i       ),
+    .secureseed_wr_in_wb_i       ( secureseed_wr_in_wb_i    ),
 
     // Interrupt Controller Signals
     .irq_req_ctrl_i              ( irq_req_ctrl_i           ),

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -88,6 +88,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
   // CSR write strobes
   input logic         cpuctrl_wr_in_wb_i,
+  input logic         secureseed_wr_in_wb_i,
 
   // Stage valid/ready signals
   input  logic        if_valid_i,       // IF stage has valid (non-bubble) data for next stage
@@ -635,6 +636,15 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
             // cpuctrl has impact on pipeline operation. When updated, clear pipeline.
             // div/divu/rem/remu and branch decisions in EX stage depend on cpuctrl.dataindtiming
             // Dummy instruction insertion depend on cpuctrl.dummyen/dummyfreq
+            ctrl_fsm_o.kill_if = 1'b1;
+            ctrl_fsm_o.kill_id = 1'b1;
+            ctrl_fsm_o.kill_ex = 1'b1;
+            ctrl_fsm_o.pc_set  = 1'b1;
+            ctrl_fsm_o.pc_mux  = PC_WB_PLUS4;
+          end else if (secureseed_wr_in_wb_i) begin
+            // The secureseed registers impact the pipeline operation. When updated, clear pipeline.
+            // Dummy instruction insertion decision and depends on secureseed0.
+            // The operands used by dummy instructions depend on secureseed1 and 2.
             ctrl_fsm_o.kill_if = 1'b1;
             ctrl_fsm_o.kill_id = 1'b1;
             ctrl_fsm_o.kill_ex = 1'b1;

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -748,6 +748,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     // CSR write strobes
     .cpuctrl_wr_in_wb_o         ( cpuctrl_wr_in_wb       ),
+    .secureseed_wr_in_wb_o      ( secureseed_wr_in_wb    ),
 
     // debug
     .dpc_o                      ( dpc                    ),
@@ -829,6 +830,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     // CSR write strobes
     .cpuctrl_wr_in_wb_i             ( cpuctrl_wr_in_wb       ),
+    .secureseed_wr_in_wb_i          ( secureseed_wr_in_wb    ),
 
     // Debug signals
     .debug_req_i                    ( debug_req_i            ),

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -266,7 +266,11 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
   // Xsecure control
   xsecure_ctrl_t xsecure_ctrl;
-  
+
+  // Dummy Instruction LFSR shift control
+  logic        lfsr_shift_if;
+  logic        lfsr_shift_id;
+
   // Internal OBI interfaces
   if_c_obi #(.REQ_TYPE(obi_inst_req_t), .RESP_TYPE(obi_inst_resp_t))  m_c_obi_instr_if();
   if_c_obi #(.REQ_TYPE(obi_data_req_t), .RESP_TYPE(obi_data_resp_t))  m_c_obi_data_if();
@@ -429,8 +433,9 @@ module cv32e40s_core import cv32e40s_pkg::*;
     // Privilege level
     .priv_lvl_ctrl_i     ( priv_lvl_if_ctrl         ),
 
-    // Dummy Instruction CSRs
+    // Dummy Instruction control
     .xsecure_ctrl_i      ( xsecure_ctrl             ),
+    .lfsr_shift_o        ( lfsr_shift_if            ),
 
     // eXtension interface
     .xif_compressed_if   ( xif_compressed_if        ),
@@ -500,6 +505,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .id_ready_o                   ( id_ready                  ),
     .id_valid_o                   ( id_valid                  ),
     .ex_ready_i                   ( ex_ready                  ),
+
+    .lfsr_shift_o                 ( lfsr_shift_id             ),
 
     // eXtension interface
     .xif_issue_if                 ( xif_issue_if              )
@@ -745,6 +752,10 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     // Xsecure control
     .xsecure_ctrl_o             ( xsecure_ctrl           ),
+
+    // LFSR shifts
+    .lfsr_shift_if_i            ( lfsr_shift_if          ),
+    .lfsr_shift_id_i            ( lfsr_shift_id          ),
 
     // CSR write strobes
     .cpuctrl_wr_in_wb_o         ( cpuctrl_wr_in_wb       ),

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -101,6 +101,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   // CSR write strobes
   output logic            cpuctrl_wr_in_wb_o,
+  output logic            secureseed_wr_in_wb_o,
 
   // debug
   output logic [31:0]     dpc_o,
@@ -953,6 +954,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   endgenerate
 
   assign cpuctrl_wr_in_wb_o = cpuctrl_we;
+  assign secureseed_wr_in_wb_o = secureseed0_we || secureseed0_we || secureseed0_we;
 
   assign csr_rdata_o = csr_rdata_int;
 

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -936,7 +936,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       assign lfsr_lockup_o = |lfsr_lockup;
 
       // Reset dummy instruction counter when writing registers that affect insertion frequency
-      assign xsecure_ctrl_o.cntrst = cpuctrl_we || secureseed0_we;
+      assign xsecure_ctrl_o.cntrst = cpuctrl_we || secureseed0_we || lfsr_lockup[0];
 
     end // block: xsecure
     else begin : no_xsecure

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -95,6 +95,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   // LFSR lockup
   output logic            lfsr_lockup_o,
+  input  logic            lfsr_shift_if_i,
+  input  logic            lfsr_shift_id_i,
 
   // Xsecure control
   output xsecure_ctrl_t   xsecure_ctrl_o,
@@ -891,6 +893,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           .rd_error_o (cpuctrl_rd_error)
         );
 
+      // Shifting LFSR0 in IF because it controls instruction insertion
       cv32e40s_lfsr #(
         .LFSR_CFG     (LFSR0_CFG)
         ) lfsr0_i (
@@ -899,11 +902,12 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           .seed_i     (secureseed0_n),
           .seed_we_i  (secureseed0_we),
           .enable_i   (cpuctrl_q.rnddummy),
-          .shift_i    (if_id_pipe_i.instr_meta.dummy), // At least one shift per dummy instruction
+          .shift_i    (lfsr_shift_if_i),
           .data_o     (xsecure_ctrl_o.lfsr0),
           .lockup_o   (lfsr_lockup[0])
         );
 
+      // Shifting lfsr 1 and 2 in ID because they control the operand values
       cv32e40s_lfsr #(
         .LFSR_CFG     (LFSR1_CFG)
         ) lfsr1_i (
@@ -912,7 +916,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           .seed_i     (secureseed1_n),
           .seed_we_i  (secureseed1_we),
           .enable_i   (cpuctrl_q.rnddummy),
-          .shift_i    (if_id_pipe_i.instr_meta.dummy), // At least one shift per dummy instruction
+          .shift_i    (lfsr_shift_id_i),
           .data_o     (xsecure_ctrl_o.lfsr1),
           .lockup_o   (lfsr_lockup[1])
         );
@@ -925,7 +929,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           .seed_i     (secureseed2_n),
           .seed_we_i  (secureseed2_we),
           .enable_i   (cpuctrl_q.rnddummy),
-          .shift_i    (if_id_pipe_i.instr_meta.dummy), // At least one shift per dummy instruction
+          .shift_i    (lfsr_shift_id_i),
           .data_o     (xsecure_ctrl_o.lfsr2),
           .lockup_o   (lfsr_lockup[2])
         );

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -935,6 +935,9 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       // Combine lockup singals for alert
       assign lfsr_lockup_o = |lfsr_lockup;
 
+      // Reset dummy instruction counter when writing registers that affect insertion frequency
+      assign xsecure_ctrl_o.cntrst = cpuctrl_we || secureseed0_we;
+
     end // block: xsecure
     else begin : no_xsecure
 

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -958,7 +958,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   endgenerate
 
   assign cpuctrl_wr_in_wb_o = cpuctrl_we;
-  assign secureseed_wr_in_wb_o = secureseed0_we || secureseed0_we || secureseed0_we;
+  assign secureseed_wr_in_wb_o = secureseed0_we || secureseed1_we || secureseed2_we;
 
   assign csr_rdata_o = csr_rdata_int;
 

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -91,6 +91,8 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   output logic        id_valid_o,     // ID stage has valid (non-bubble) data for next stage
   input  logic        ex_ready_i,     // EX stage is ready for new data
 
+  output logic        lfsr_shift_o,
+
   // eXtension interface
   if_xif.cpu_issue  xif_issue_if
 );
@@ -203,6 +205,9 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   assign sys_en_o = sys_en;
   assign sys_mret_insn_o = sys_mret_insn;
   assign sys_wfi_insn_o  = sys_wfi_insn;
+
+  // Ensures one shift of the operand LFSRs for each dummy instruction in ID
+  assign lfsr_shift_o    = (id_valid_o && ex_ready_i) && if_id_pipe_i.instr_meta.dummy;
 
   assign instr = if_id_pipe_i.instr.bus_resp.rdata;
 

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -73,8 +73,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   // Privilege mode
   input privlvlctrl_t   priv_lvl_ctrl_i,
 
-  // Dummy Instruction CSRs
+  // Dummy Instruction Control
   input xsecure_ctrl_t  xsecure_ctrl_i,
+  output  logic         lfsr_shift_o,
 
   // eXtension interface
   if_xif.cpu_compressed xif_compressed_if,      // XIF compressed interface
@@ -253,6 +254,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   assign if_valid_o = instr_valid;
 
   assign if_busy_o = prefetch_busy;
+
+  // Ensures one shift of lfsr0 for each instruction inserted in IF
+  assign lfsr_shift_o = (if_valid_o && id_ready_i) && dummy_insert;
 
   // Populate instruction meta data
   instr_meta_t instr_meta_n;

--- a/rtl/cv32e40s_register_file.sv
+++ b/rtl/cv32e40s_register_file.sv
@@ -103,8 +103,10 @@ module cv32e40s_register_file import cv32e40s_pkg::*;
           mem[0] <= '0;
         end else begin
           if (dummy_instr_wb_i) begin
-            if(we_dec[0][0] == 1'b1) begin
-              mem[0] <= wdata_i[0];
+            for(int j=0; j<REGFILE_NUM_WRITE_PORTS; j++) begin : dummy_rf_write_ports
+              if(we_dec[j][0] == 1'b1) begin
+                mem[0] <= wdata_i[j];
+              end
             end
           end else begin
             mem[0] <= '0;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -485,6 +485,7 @@ typedef struct packed {
   logic [31:0] lfsr1;
   logic [31:0] lfsr0;
   cpuctrl_t    cpuctrl;
+  logic        cntrst;
 } xsecure_ctrl_t;
 
 // Privileged mode

--- a/sva/cv32e40s_dummy_instr_sva.sv
+++ b/sva/cv32e40s_dummy_instr_sva.sv
@@ -33,36 +33,15 @@ module cv32e40s_dummy_instr_sva
    input logic                 rst_n,
 
    input logic                 dummy_insert_o,
-   input logic                 cpuctrl_we,
-   input cpuctrl_t             cpuctrl_n,
-   input logic                 secureseed0_we,
-   input logic [31:0]          secureseed0_n,
    input xsecure_ctrl_t        xsecure_ctrl_i,
    input logic [CNT_WIDTH-1:0] cnt_q,
    input logic [5:0]           lfsr_cnt
    );
 
-  // Check whether the randomization conditions have been changed by software
-  logic                        sw_reg_update;
-  always_ff @(posedge clk, negedge rst_n) begin
-    if (rst_n == 1'b0) begin
-      sw_reg_update <= '0;
-    end else begin
-      if (cpuctrl_we && (cpuctrl_n.rnddummyfreq != xsecure_ctrl_i.cpuctrl.rnddummyfreq)) begin
-        sw_reg_update <= 1'b1;
-      end else if (secureseed0_we && (secureseed0_n != xsecure_ctrl_i.lfsr0)) begin
-        sw_reg_update <= 1'b1;
-      end else if (dummy_insert_o) begin
-        sw_reg_update <= 1'b0;
-      end
-    end
-  end
-
   // Assert that counter stopped correctly when inserting dummy instruction
-  // The count is allowed to be off when the randomization conditions have been changed by software
   a_no_count_overflow :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     dummy_insert_o |-> (cnt_q == lfsr_cnt + 1) || sw_reg_update)
+                     dummy_insert_o |-> (cnt_q == lfsr_cnt + 1))
       else `uvm_error("Dummy Instruction Insertion", "Counter counted further than lfsr_cnt + 1");
 
   // Assert that we never count when counter has passed the compare value

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -160,6 +160,20 @@ module cv32e40s_id_stage_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                      rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && if_id_pipe_i.instr_meta.dummy |-> (operand_b_fw == rf_rdata_i[1]))
       else `uvm_error("id_stage", "Dummy instruction could not read from R0 (on read port 1)")
+
+  a_dummy_opa_mux_check:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     if_id_pipe_i.instr_meta.dummy |-> ( (ctrl_byp_i.operand_a_fw_mux_sel == SEL_LFSR) ||
+                                                        ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[0] == 0))))
+      else `uvm_error("id_stage", "Illegal operand a mux select value for dummy instruction")
+
+  a_dummy_opb_mux_check:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                     if_id_pipe_i.instr_meta.dummy |-> ( (ctrl_byp_i.operand_b_fw_mux_sel == SEL_LFSR) ||
+                                                        ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[1] == 0))))
+      else `uvm_error("id_stage", "Illegal operand b mux select value for dummy instruction")
+
+
   // Ensure that functional unit enables are one-hot (ALU and DIV both use the ALU though)
   a_functional_unit_enable_onehot :
     assert property (@(posedge clk) disable iff (!rst_n)

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -64,6 +64,7 @@ module cv32e40s_id_stage_sva
   input logic           id_ready_o,
   input logic           id_valid_o,
   input ctrl_fsm_t      ctrl_fsm_i,
+  input ctrl_byp_t      ctrl_byp_i,
   input mstatus_t       mstatus_i,
   input logic           xif_insn_accept
 );


### PR DESCRIPTION
Addressed issues pointed out in #92  :
 - Updated dummy instruction assertions to not have special case around writes.
 - Updated dummy instruction insertion counter to reset when insertion frequency controls are updated.
 - Made dummy instruction part of register file support REGFILE_NUM_WRITE_PORTS

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>