### PR TITLE
Instantiated shadow flops for csr hardening

### DIFF
--- a/bhv/cv32e40s_sim_sffr.sv
+++ b/bhv/cv32e40s_sim_sffr.sv
@@ -1,0 +1,52 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License");
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Halfdan Bechmann - halfdan.bechmann@silabs.com             //
+//                                                                            //
+// Design Name:    cv32e40s_sffr                                              //
+// Project Name:   CV32E40S                                                   //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    Emulates an instantiated sffr                              //
+//                 This file is meant for rtl simulation only!                //
+//                 It should not be used for ASIC synthesis.                  //
+//                 It should not be used for FPGA synthesis.                  //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40s_sffr
+#(
+  parameter LIB = 0
+  )
+  (
+   input  logic  clk,
+   input  logic  rst_n,
+   input  logic  d_i,
+   output logic  q_o
+   );
+
+  always_ff @(posedge clk, negedge rst_n) begin
+    if (rst_n == 1'b0) begin
+      q_o <= 1'b0;
+    end else begin
+      q_o <= d_i;
+    end
+  end
+
+endmodule : cv32e40s_sffr
+

--- a/bhv/cv32e40s_sim_sffs.sv
+++ b/bhv/cv32e40s_sim_sffs.sv
@@ -1,0 +1,52 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License");
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Halfdan Bechmann - halfdan.bechmann@silabs.com             //
+//                                                                            //
+// Design Name:    cv32e40s_sffs                                              //
+// Project Name:   CV32E40S                                                   //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    Emulates an instantiated sffs                              //
+//                 This file is meant for rtl simulation only!                //
+//                 It should not be used for ASIC synthesis.                  //
+//                 It should not be used for FPGA synthesis.                  //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40s_sffs
+#(
+  parameter LIB = 0
+  )
+  (
+   input  logic  clk,
+   input  logic  set_n,
+   input  logic  d_i,
+   output logic  q_o
+   );
+
+  always_ff @(posedge clk, negedge set_n) begin
+    if (set_n == 1'b0) begin
+      q_o <= 1'b1;
+    end else begin
+      q_o <= d_i;
+    end
+  end
+
+endmodule : cv32e40s_sffs
+

--- a/bhv/cv32e40s_sim_sffs.sv
+++ b/bhv/cv32e40s_sim_sffs.sv
@@ -35,13 +35,13 @@ module cv32e40s_sffs
   )
   (
    input  logic  clk,
-   input  logic  set_n,
+   input  logic  rst_n,
    input  logic  d_i,
    output logic  q_o
    );
 
-  always_ff @(posedge clk, negedge set_n) begin
-    if (set_n == 1'b0) begin
+  always_ff @(posedge clk, negedge rst_n) begin
+    if (rst_n == 1'b0) begin
       q_o <= 1'b1;
     end else begin
       q_o <= d_i;

--- a/cv32e40s_manifest.flist
+++ b/cv32e40s_manifest.flist
@@ -76,5 +76,7 @@ ${DESIGN_RTL_DIR}/cv32e40s_pmp.sv
 ${DESIGN_RTL_DIR}/cv32e40s_pc_target.sv
 ${DESIGN_RTL_DIR}/cv32e40s_lfsr.sv
 
+${DESIGN_RTL_DIR}/../bhv/cv32e40s_sim_sffr.sv
+${DESIGN_RTL_DIR}/../bhv/cv32e40s_sim_sffs.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40s_sim_clock_gate.sv
 ${DESIGN_RTL_DIR}/../bhv/cv32e40s_rvfi.sv

--- a/docs/user_manual/source/getting_started.rst
+++ b/docs/user_manual/source/getting_started.rst
@@ -28,3 +28,37 @@ Inside |corev|, the clock gating cell is used in ``cv32e40s_sleep_unit.sv``.
 The ``cv32e40s_sim_clock_gate.sv`` file is not intended for synthesis. For ASIC synthesis and FPGA synthesis the manifest
 should be adapted to use a customer specific file that implements the ``cv32e40s_clock_gate`` module using design primitives
 that are appropriate for the intended synthesis target technology.
+
+
+.. _register-cells:
+
+Register Cells
+--------------
+|corev| requires instantiated registers for some logically redundant security features (such as :ref:`hardened-csrs`).
+
+Like clock gating cells these are specific to the target technology and are therefore not provided as part of the RTL design.
+Simulation-only versions for these cells are provided in cv32e40s_sim_sffr.sv and cv32e40s_sim_sffs.sv.
+cv32e40s_sim_sffr.sv contains the module ``cv32e40s_sffr`` with the following ports:
+
+* ``clk``   : Clock
+* ``rst_n`` : Reset
+* ``d_i``   : Data input
+* ``q_o``   : Flopped data output
+
+And the following parameters:
+* ``LIB`` : Standard cell library (semantics defined by integrator)
+
+cv32e40s_sim_sffs.sv contains the module ``cv32e40s_sffs`` with the following ports:
+
+* ``clk``   : Clock
+* ``set_n`` : Set (i.e., reset value == 1)
+* ``d_i``   : Data input
+* ``q_o``   : Flopped data output
+
+And the following parameters:
+* ``LIB`` : Standard cell library (semantics defined by integrator)
+
+These files are not intended for synthesis.
+For ASIC synthesis and FPGA synthesis the manifest should be adapted
+to use customer specific files that implement the ``cv32e40s_sffr`` and ``cv32e40s_sffs`` modules
+using design primitives that are appropriate for the intended synthesis target technology.

--- a/docs/user_manual/source/xsecure.rst
+++ b/docs/user_manual/source/xsecure.rst
@@ -124,6 +124,8 @@ Hardened PC
 -----------
 Checking is performed to ensure that the PC increments as expected for sequential code. See https://ibex-core.readthedocs.io/en/latest/03_reference/security.html.
 
+.. _hardened-csrs:
+
 Hardened CSRs
 -------------
 Critical CSRs (``mstatus``, ``mtvec``, ``pmpcfg``, ``pmpaddr*``, ``mseccfg*``, ``cpuctrl``, ``dcsr``, ``mie`` and ``mepc``) have extra glitch detection enabled.
@@ -131,7 +133,7 @@ For these registers a second copy of the register is added which stores a comple
 
 .. note::
   The shadow copies are logically redundant and are therefore likely to be optimized away during synthesis.
-  Special care in the synthesis script is necessary and the final netlist must be checked to ensure that the shadow copies are still present.
+  Special care in the synthesis script is necessary (see :ref:`register-cells`) and the final netlist must be checked to ensure that the shadow copies are still present.
   A netlist test for this feature is recommended.
 
 Control flow hardening

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -711,6 +711,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   (
     .clk                        ( clk                    ),
     .rst_n                      ( rst_ni                 ),
+    .scan_cg_en_i               ( scan_cg_en_i           ),
 
     // Hart ID from outside
     .hart_id_i                  ( hart_id_i              ),

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -38,7 +38,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   parameter bit        A_EXT            = 0,
   parameter m_ext_e    M_EXT            = M,
   parameter bit        X_EXT            = 0,
-  parameter int        X_MISA           = 32'h00000000, 
+  parameter int        X_MISA           = 32'h00000000,
   parameter int        PMP_NUM_REGIONS  = 0,
   parameter int        PMP_GRANULARITY  = 0,
   parameter            NUM_MHPMCOUNTERS = 1,
@@ -50,12 +50,13 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   // Clock and Reset
   input  logic            clk,
   input  logic            rst_n,
+  input  logic            scan_cg_en_i,
 
   // Hart ID
   input  logic [31:0]     hart_id_i,
   output logic [23:0]     mtvec_addr_o,
   output logic [ 1:0]     mtvec_mode_o,
-  
+
   // Used for mtvec address
   input  logic [31:0]     mtvec_addr_i,
   input  logic            csr_mtvec_init_i,
@@ -65,7 +66,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   input  logic            sys_en_id_i,
   input  logic            sys_mret_id_i,
 
-  // ID/EX pipeline 
+  // ID/EX pipeline
   input  id_ex_pipe_t     id_ex_pipe_i,
 
   // EX/WB pipeline
@@ -76,7 +77,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   // To controller bypass logic
   output logic            csr_counter_read_o,
- 
+
   // Interface to registers (SRAM like)
   output logic [31:0]     csr_rdata_o,
 
@@ -87,7 +88,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   output logic [31:0]     mie_o,
   input  logic [31:0]     mip_i,
   output logic            m_irq_enable_o,
-  
+
   output logic [31:0]     mepc_o,
 
   // PMP CSR's
@@ -121,7 +122,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   input  logic [31:0]     pc_if_i
 );
-  
+
   localparam logic [31:0] CORE_MISA =
   (32'(A_EXT)      <<  0)  // A - Atomic Instructions extension
 | (32'(1)          <<  2)  // C - Compressed extension
@@ -756,6 +757,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   ) dscratch0_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (dscratch0_n),
     .wr_en_i    (dscratch0_we),
     .rd_data_o  (dscratch0_q),
@@ -769,6 +771,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   ) dscratch1_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (dscratch1_n),
     .wr_en_i    (dscratch1_we),
     .rd_data_o  (dscratch1_q),
@@ -777,11 +780,13 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
  cv32e40s_csr #(
     .WIDTH      (32),
+    .MASK       (CSR_DCSR_MASK),
     .SHADOWCOPY (SECURE),
     .RESETVALUE (DCSR_RESET_VAL)
   ) dcsr_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (dcsr_n),
     .wr_en_i    (dcsr_we),
     .rd_data_o  (dcsr_q),
@@ -795,6 +800,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   ) dpc_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (dpc_n),
     .wr_en_i    (dpc_we),
     .rd_data_o  (dpc_q),
@@ -803,11 +809,13 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   cv32e40s_csr #(
     .WIDTH      (32),
+    .MASK       (CSR_MEPC_MASK),
     .SHADOWCOPY (SECURE),
     .RESETVALUE (32'd0)
   ) mepc_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (mepc_n),
     .wr_en_i    (mepc_we),
     .rd_data_o  (mepc_q),
@@ -821,6 +829,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   ) mscratch_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (mscratch_n),
     .wr_en_i    (mscratch_we),
     .rd_data_o  (mscratch_q),
@@ -829,11 +838,13 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   cv32e40s_csr #(
     .WIDTH      (32),
+    .MASK       (IRQ_MASK),
     .SHADOWCOPY (SECURE),
     .RESETVALUE (32'd0)
   ) mie_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (mie_n),
     .wr_en_i    (mie_we),
     .rd_data_o  (mie_q),
@@ -842,11 +853,13 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   cv32e40s_csr #(
     .WIDTH      (32),
+    .MASK       (CSR_MSTATUS_MASK),
     .SHADOWCOPY (SECURE),
     .RESETVALUE (MSTATUS_RESET_VAL)
   ) mstatus_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (mstatus_n),
     .wr_en_i    (mstatus_we),
     .rd_data_o  (mstatus_q),
@@ -860,21 +873,23 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   ) mcause_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (mcause_n),
     .wr_en_i    (mcause_we),
     .rd_data_o  (mcause_q),
     .rd_error_o (mcause_rd_error)
   );
 
-  
 
   cv32e40s_csr #(
     .WIDTH      (32),
+    .MASK       (CSR_MTVEC_MASK),
     .SHADOWCOPY (SECURE),
     .RESETVALUE (MTVEC_RESET_VAL)
   ) mtvec_csr_i (
     .clk      (clk),
     .rst_n     (rst_n),
+    .scan_cg_en_i (scan_cg_en_i),
     .wr_data_i  (mtvec_n),
     .wr_en_i    (mtvec_we),
     .rd_data_o  (mtvec_q),
@@ -888,11 +903,13 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       cv32e40s_csr #(
         .WIDTH      (32),
+        .MASK       (CSR_CPUCTRL_MASK),
         .SHADOWCOPY (SECURE),
         .RESETVALUE (32'd0)
         ) cpuctrl_csr_i (
           .clk        (clk),
           .rst_n      (rst_n),
+          .scan_cg_en_i (scan_cg_en_i),
           .wr_data_i  (cpuctrl_n),
           .wr_en_i    (cpuctrl_we),
           .rd_data_o  (cpuctrl_q),
@@ -1075,19 +1092,21 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
               default : pmp_cfg_n[i].mode = PMP_MODE_OFF;
             endcase
           end
-          
+
           cv32e40s_csr #(
                          .WIDTH      ($bits(pmp_cfg_t)),
+                         .MASK       (CSR_PMPCFG_MASK),
                          .SHADOWCOPY (SECURE),
                          .RESETVALUE ('0))
-          pmp_cfg_csr_i 
+          pmp_cfg_csr_i
             (.clk        (clk),
              .rst_n      (rst_n),
+             .scan_cg_en_i (scan_cg_en_i),
              .wr_data_i  (pmp_cfg_n[i]),
              .wr_en_i    (pmp_cfg_we[i]),
              .rd_data_o  (pmp_cfg_q[i]),
              .rd_error_o (pmp_cfg_rd_error[i]));
-          
+
           assign csr_pmp_o.cfg[i] = pmp_cfg_q[i];
 
           if (i == PMP_NUM_REGIONS-1) begin: pmp_addr_qual_upper
@@ -1100,14 +1119,16 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
                                     !pmp_cfg_locked[i] &&
                                     (!pmp_cfg_locked[i+1] || pmp_cfg_q[i+1].mode != PMP_MODE_TOR);
           end
-          
+
           cv32e40s_csr #(
                          .WIDTH      (PMP_ADDR_WIDTH),
+                         .MASK       (CSR_PMPADDR_MASK),
                          .SHADOWCOPY (SECURE),
                          .RESETVALUE ('0))
-          pmp_addr_csr_i 
+          pmp_addr_csr_i
             (.clk        (clk),
              .rst_n      (rst_n),
+             .scan_cg_en_i (scan_cg_en_i),
              .wr_data_i  (pmp_addr_n),
              .wr_en_i    (pmp_addr_we[i]),
              .rd_data_o  (pmp_addr_q[i]),
@@ -1168,7 +1189,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       // MSECFG.RLB cannot be set if any PMP region is locked
       // TODO:OE Spec: When mseccfg.RLB is 0 and pmpcfg.L is 1 in any entry (including disabled entries), then mseccfg.RLB is locked and any further modifications to mseccfg.RLB are ignored (WARL). Ibex version would clear RLB upon MSECCFG write if any region is locked, even if RLB=1.
-      
+
       // Ibex version: assign pmp_mseccfg_n.rlb = csr_wdata_int[CSR_MSECCFG_RLB_BIT]  && !(|pmp_cfg_locked);
 
       // MSECCFG.RLB cannot be set if RLB=0 and any PMP region is locked
@@ -1176,14 +1197,16 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
                                       csr_wdata_int[CSR_MSECCFG_RLB_BIT] && !(|pmp_cfg_locked);
 
       assign pmp_mseccfg_n.zero0 = '0;
-      
+
       cv32e40s_csr #(
                      .WIDTH      ($bits(pmp_mseccfg_t)),
+                     .MASK       (CSR_MSECCFG_MASK),
                      .SHADOWCOPY (SECURE),
                      .RESETVALUE ('0))
-      pmp_mseccfg_csr_i 
+      pmp_mseccfg_csr_i
         (.clk        (clk),
          .rst_n      (rst_n),
+         .scan_cg_en_i (scan_cg_en_i),
          .wr_data_i  (pmp_mseccfg_n),
          .wr_en_i    (pmp_mseccfg_we),
          .rd_data_o  (pmp_mseccfg_q),

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -500,10 +500,10 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   begin
     mscratch_n               = csr_wdata_int;
     mscratch_we              = 1'b0;
-    mepc_n                   = csr_wdata_int & ~32'b1;
+    mepc_n                   = csr_wdata_int & CSR_MEPC_MASK;
     mepc_we                  = 1'b0;
     dpc_n                    = csr_wdata_int & ~32'b1;
-    dpc_we                   = 1'b0; 
+    dpc_we                   = 1'b0;
 
     dcsr_n                   = '{
                                 xdebugver : dcsr_q.xdebugver,
@@ -561,7 +561,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     pmp_addr_we_int = {PMP_MAX_REGIONS{1'b0}};
     pmp_mseccfg_we  = 1'b0;
 
-    cpuctrl_n       = csr_wdata_int;
+    cpuctrl_n       = csr_wdata_int & CSR_CPUCTRL_MASK;
     cpuctrl_we      = 1'b0;
     secureseed0_n   = csr_wdata_int;
     secureseed0_we  = 1'b0;

--- a/rtl/cv32e40s_csr.sv
+++ b/rtl/cv32e40s_csr.sv
@@ -30,7 +30,7 @@ module cv32e40s_csr #(
 
   generate
     if (SHADOWCOPY) begin : gen_hardened
-      logic             cg_clk;
+      logic             clk_gated;
       logic [WIDTH-1:0] rdata_d;
       logic [WIDTH-1:0] shadow_d;
       logic [WIDTH-1:0] shadow_q;
@@ -43,18 +43,18 @@ module cv32e40s_csr #(
         (.clk_i        ( clk          ),
          .en_i         ( wr_en_i      ),
          .scan_cg_en_i ( scan_cg_en_i ),
-         .clk_o        ( cg_clk       ));
+         .clk_o        ( clk_gated    ));
 
       // The shadow registers are logically redundant and are therefore easily optimized away by most synthesis tools.
       // These registers are therefore implemented as instantiated cells so that they can be preserved in the synthesis script.
       for (genvar i = 0; i < WIDTH; i++) begin : gen_csr
         if (MASK[i]) begin : gen_unmasked
           if (RESETVALUE[i] == 1'b1) begin : gen_rv1
-            cv32e40s_sffs sffs_rdatareg  (.clk(cg_clk), .rst_n(rst_n), .d_i(rdata_d[i]),  .q_o(rdata_q[i]));
-            cv32e40s_sffr sffr_shadowreg (.clk(cg_clk), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
+            cv32e40s_sffs sffs_rdatareg  (.clk(clk_gated), .rst_n(rst_n), .d_i(rdata_d[i]),  .q_o(rdata_q[i]));
+            cv32e40s_sffr sffr_shadowreg (.clk(clk_gated), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
           end else begin : gen_rv0 // (RESETVALUE[i] == 1'b0)
-            cv32e40s_sffr sffr_rdatareg  (.clk(cg_clk), .rst_n(rst_n), .d_i(rdata_d[i]),  .q_o(rdata_q[i]));
-            cv32e40s_sffs sffs_shadowreg (.clk(cg_clk), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
+            cv32e40s_sffr sffr_rdatareg  (.clk(clk_gated), .rst_n(rst_n), .d_i(rdata_d[i]),  .q_o(rdata_q[i]));
+            cv32e40s_sffs sffs_shadowreg (.clk(clk_gated), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
           end
         end else begin : gen_masked
           assign rdata_q[i]  = 1'b0;

--- a/rtl/cv32e40s_csr.sv
+++ b/rtl/cv32e40s_csr.sv
@@ -15,6 +15,7 @@ module cv32e40s_csr #(
  ) (
     input  logic             clk,
     input  logic             rst_n,
+    input  logic             scan_cg_en_i,
 
     input  logic [WIDTH-1:0] wr_data_i,
     input  logic             wr_en_i,
@@ -23,45 +24,56 @@ module cv32e40s_csr #(
     output logic             rd_error_o
 );
 
-  logic [WIDTH-1:0] rdata_q;
-
-  always_ff @(posedge clk or negedge rst_n) begin
-    if (!rst_n) begin
-      rdata_q <= RESETVALUE & MASK;
-    end else if (wr_en_i) begin
-      rdata_q <= wr_data_i & MASK;
-    end
-  end
+  logic [WIDTH-1:0]          rdata_q;
 
   assign rd_data_o = rdata_q;
 
   generate
-    if (SHADOWCOPY) begin : gen_shadow
+    if (SHADOWCOPY) begin : gen_hardened
+      logic             cg_clk;
+      logic [WIDTH-1:0] rdata_d;
+      logic [WIDTH-1:0] shadow_d;
+      logic [WIDTH-1:0] shadow_q;
+
+      assign rdata_d    =  wr_data_i;
+      assign shadow_d   = ~wr_data_i;
+      assign rd_error_o = rdata_q != ~shadow_q;
+
+      cv32e40s_clock_gate core_clock_gate_i
+        (.clk_i        ( clk          ),
+         .en_i         ( wr_en_i      ),
+         .scan_cg_en_i ( scan_cg_en_i ),
+         .clk_o        ( cg_clk       ));
+
       // The shadow registers are logically redundant and are therefore easily optimized away by most synthesis tools.
       // These registers are therefore implemented as instantiated cells so that they can be preserved in the synthesis script.
-
-      logic [WIDTH-1:0] shadow_q;
-      logic [WIDTH-1:0] shadow_d;
-
-      for (genvar i = 0; i < WIDTH; i++) begin : gen_shadow_regs
+      for (genvar i = 0; i < WIDTH; i++) begin : gen_csr
         if (MASK[i]) begin : gen_unmasked
-          assign shadow_d[i] = wr_en_i ? wr_data_i[i] : shadow_q[i];
           if (RESETVALUE[i] == 1'b1) begin : gen_rv1
-            cv32e40s_sffs sffs_shadowreg (.clk(clk), .set_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
+            cv32e40s_sffs sffs_rdatareg  (.clk(cg_clk), .rst_n(rst_n), .d_i(rdata_d[i]),  .q_o(rdata_q[i]));
+            cv32e40s_sffr sffr_shadowreg (.clk(cg_clk), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
           end else begin : gen_rv0 // (RESETVALUE[i] == 1'b0)
-            cv32e40s_sffr sffr_shadowreg (.clk(clk), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
+            cv32e40s_sffr sffr_rdatareg  (.clk(cg_clk), .rst_n(rst_n), .d_i(rdata_d[i]),  .q_o(rdata_q[i]));
+            cv32e40s_sffs sffs_shadowreg (.clk(cg_clk), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
           end
         end else begin : gen_masked
-          assign shadow_q[i] = 1'b0;
+          assign rdata_q[i]  = 1'b0;
+          assign shadow_q[i] = 1'b1;
         end
       end
 
-    assign rd_error_o = rdata_q != ~shadow_q;
+    end else begin : gen_unhardened
 
-  end else begin : gen_no_shadow
-    assign rd_error_o = 1'b0;
-  end
+      always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+          rdata_q <= RESETVALUE & MASK;
+        end else if (wr_en_i) begin
+          rdata_q <= wr_data_i & MASK;
+        end
+      end
 
+      assign rd_error_o = 1'b0;
+    end
   endgenerate
 
 endmodule

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -451,6 +451,17 @@ typedef enum logic[11:0] {
   CSR_SECURESEED2    = 12'hBFC
 } csr_num_e;
 
+// CSR Bit Implementation Masks for hardened registers
+parameter CSR_DCSR_MASK     = 32'b1111_0000_0000_0000_1000_1001_1100_0111; // NMI bit taken from ctrl_fsm
+parameter CSR_MEPC_MASK     = ~32'b1;
+//        CSR_MIE_MASK      = IRQ_MASK;
+parameter CSR_MSTATUS_MASK  = 32'b0000_0000_0010_0010_0001_1000_1000_1000;
+parameter CSR_MTVEC_MASK    = 32'hFFFFFF01;
+parameter CSR_CPUCTRL_MASK  = 32'h000F000F;
+parameter CSR_PMPCFG_MASK   = ~32'h0;
+parameter CSR_PMPADDR_MASK  = ~32'h0;
+parameter CSR_MSECCFG_MASK  = 32'h00000007;
+
 // CSR operations
 
 parameter CSR_OP_WIDTH = 2;


### PR DESCRIPTION
Instantiated shadow flops for csr hardening to avoid them being optimized away.

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>