### PR TITLE
Timing fix

### DIFF
--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -87,8 +87,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   input  logic        csr_counter_read_i,         // A performance counter is read in CSR (EX)
 
   // CSR write stobes
-  input logic          cpuctrl_wr_in_wb_i,
-  input logic          secureseed_wr_in_wb_i,
+  input logic          xsecure_csr_wr_in_wb_i,
 
   input logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_id_i,
   input rf_addr_t     rf_raddr_id_i[REGFILE_NUM_READ_PORTS],
@@ -162,8 +161,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     .lsu_interruptible_i         ( lsu_interruptible_i      ),
 
     // CSR write strobes
-    .cpuctrl_wr_in_wb_i          ( cpuctrl_wr_in_wb_i       ),
-    .secureseed_wr_in_wb_i       ( secureseed_wr_in_wb_i    ),
+    .xsecure_csr_wr_in_wb_i      ( xsecure_csr_wr_in_wb_i   ),
 
     // Interrupt Controller Signals
     .irq_req_ctrl_i              ( irq_req_ctrl_i           ),

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -87,8 +87,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   output ctrl_fsm_t   ctrl_fsm_o,
 
   // CSR write strobes
-  input logic         cpuctrl_wr_in_wb_i,
-  input logic         secureseed_wr_in_wb_i,
+  input logic         xsecure_csr_wr_in_wb_i,
 
   // Stage valid/ready signals
   input  logic        if_valid_i,       // IF stage has valid (non-bubble) data for next stage
@@ -632,19 +631,10 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
             single_step_halt_if_n = 1'b0;
             debug_mode_n  = 1'b0;
-          end else if (cpuctrl_wr_in_wb_i) begin
-            // cpuctrl has impact on pipeline operation. When updated, clear pipeline.
+          end else if (xsecure_csr_wr_in_wb_i) begin
+            // xsecure CSRs has impact on pipeline operation. When updated, clear pipeline.
             // div/divu/rem/remu and branch decisions in EX stage depend on cpuctrl.dataindtiming
             // Dummy instruction insertion depend on cpuctrl.dummyen/dummyfreq
-            ctrl_fsm_o.kill_if = 1'b1;
-            ctrl_fsm_o.kill_id = 1'b1;
-            ctrl_fsm_o.kill_ex = 1'b1;
-            ctrl_fsm_o.pc_set  = 1'b1;
-            ctrl_fsm_o.pc_mux  = PC_WB_PLUS4;
-          end else if (secureseed_wr_in_wb_i) begin
-            // The secureseed registers impact the pipeline operation. When updated, clear pipeline.
-            // Dummy instruction insertion decision and depends on secureseed0.
-            // The operands used by dummy instructions depend on secureseed1 and 2.
             ctrl_fsm_o.kill_if = 1'b1;
             ctrl_fsm_o.kill_id = 1'b1;
             ctrl_fsm_o.kill_ex = 1'b1;

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -176,7 +176,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
   logic [31:0] csr_rdata;
   logic csr_counter_read;
-  logic cpuctrl_wr_in_wb;
+  logic xsecure_csr_wr_in_wb;
 
   privlvl_t     priv_lvl_lsu, priv_lvl;
   privlvlctrl_t priv_lvl_if_ctrl;
@@ -768,8 +768,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .lfsr_shift_id_i            ( lfsr_shift_id          ),
 
     // CSR write strobes
-    .cpuctrl_wr_in_wb_o         ( cpuctrl_wr_in_wb       ),
-    .secureseed_wr_in_wb_o      ( secureseed_wr_in_wb    ),
+    .xsecure_csr_wr_in_wb_o     ( xsecure_csr_wr_in_wb   ),
 
     // debug
     .dpc_o                      ( dpc                    ),
@@ -850,8 +849,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .mtvec_mode_i                   ( mtvec_mode             ),
 
     // CSR write strobes
-    .cpuctrl_wr_in_wb_i             ( cpuctrl_wr_in_wb       ),
-    .secureseed_wr_in_wb_i          ( secureseed_wr_in_wb    ),
+    .xsecure_csr_wr_in_wb_i         ( xsecure_csr_wr_in_wb   ),
 
     // Debug signals
     .debug_req_i                    ( debug_req_i            ),

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -105,8 +105,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   output xsecure_ctrl_t   xsecure_ctrl_o,
 
   // CSR write strobes
-  output logic            cpuctrl_wr_in_wb_o,
-  output logic            secureseed_wr_in_wb_o,
+  output logic            xsecure_csr_wr_in_wb_o,
 
   // debug
   output logic [31:0]     dpc_o,
@@ -248,6 +247,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   csr_num_e    csr_raddr;
   logic [31:0] csr_wdata;
   logic        csr_en_gated;
+  logic        csr_wr_in_wb;
 
   logic illegal_csr_read;  // Current CSR cannot be read
   logic illegal_csr_write; // Current CSR cannot be written
@@ -963,8 +963,19 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     end
   endgenerate
 
-  assign cpuctrl_wr_in_wb_o = cpuctrl_we;
-  assign secureseed_wr_in_wb_o = secureseed0_we || secureseed1_we || secureseed2_we;
+
+  assign csr_wr_in_wb = ex_wb_pipe_i.csr_en &&
+                        ex_wb_pipe_i.instr_valid &&
+                        ((csr_op == CSR_OP_WRITE) ||
+                         (csr_op == CSR_OP_SET)   ||
+                         (csr_op == CSR_OP_CLEAR));
+
+  assign xsecure_csr_wr_in_wb_o = SECURE &&
+                                  csr_wr_in_wb &&
+                                  ((csr_waddr == CSR_CPUCTRL)     ||
+                                   (csr_waddr == CSR_SECURESEED0) ||
+                                   (csr_waddr == CSR_SECURESEED1) ||
+                                   (csr_waddr == CSR_SECURESEED2));
 
   assign csr_rdata_o = csr_rdata_int;
 


### PR DESCRIPTION
Combine cpuctrl_wr_in_wb and secureseed_wr_in_wb into xsecure_csr_wr_in_wb.
Make xsecure_csr_wr_in_wb independent of control signals from FSM to ease timing.

SEC clean