### PR TITLE
Precursor to PC hardening, multi cycle jumps and branches

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -220,6 +220,7 @@ module cv32e40s_wrapper
                               .csr_illegal_i       (core_i.cs_registers_i.csr_illegal_o),
                               .xif_commit_kill     (core_i.xif_commit_if.commit.commit_kill),
                               .xif_commit_valid    (core_i.xif_commit_if.commit_valid),
+                              .last_op_id_i        (core_i.controller_i.last_op_id_i),
                               .*);
   bind cv32e40s_cs_registers:        core_i.cs_registers_i              cv32e40s_cs_registers_sva cs_registers_sva (.*);
 

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -168,6 +168,7 @@ module cv32e40s_wrapper
   bind cv32e40s_id_stage:
     core_i.id_stage_i cv32e40s_id_stage_sva id_stage_sva
     (
+      .ex_wb_pipe      (core_i.ex_wb_pipe),
       .*
     );
 
@@ -266,7 +267,7 @@ module cv32e40s_wrapper
                 .ctrl_debug_mode_n                (core_i.controller_i.controller_fsm_i.debug_mode_n),
                 .ctrl_pending_debug               (core_i.controller_i.controller_fsm_i.pending_debug),
                 .ctrl_debug_allowed               (core_i.controller_i.controller_fsm_i.debug_allowed),
-                .id_stage_multi_cycle_id_stall    (core_i.id_stage_i.multi_cycle_id_stall),
+                .id_stage_multi_op_id_stall       (core_i.id_stage_i.multi_op_id_stall),
                 .id_stage_id_valid                (core_i.id_stage_i.id_valid_o),
                 .priv_lvl_if                      (core_i.if_stage_i.prefetch_priv_lvl),
                 .priv_lvl_if_q                    (core_i.if_stage_i.prefetch_unit_i.alignment_buffer_i.instr_priv_lvl_q),

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -56,6 +56,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   input  logic        csr_en_id_i,
   input  csr_opcode_e csr_op_id_i,
   input  logic        sys_wfi_id_i,
+  input  logic        last_op_id_i,
 
   input  id_ex_pipe_t id_ex_pipe_i,
   input  ex_wb_pipe_t ex_wb_pipe_i,
@@ -214,6 +215,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     .csr_en_id_i                ( csr_en_id_i              ),
     .csr_op_id_i                ( csr_op_id_i              ),
     .sys_wfi_id_i               ( sys_wfi_id_i             ),
+    .last_op_id_i               ( last_op_id_i             ),
 
     // From EX
     .csr_counter_read_i         ( csr_counter_read_i       ),

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -121,9 +121,12 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
 
   // Detect when a CSR insn  in in EX or WB
   // mret and dret implicitly writes to CSR. (dret is killing IF/ID/EX once it is in WB and can be disregarded here.
+  // Only the last part of multi cycle mrets update mstatus and privilege level. Factoring in last_op avoids
+  // stalling the second part of an mret when the first part is already in EX or WB.
+
   assign csr_write_in_ex_wb = (
-                              (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || (id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn))) ||
-                              (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn)))
+                              (id_ex_pipe_i.instr_valid && (id_ex_pipe_i.csr_en || (id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && id_ex_pipe_i.last_op))) ||
+                              (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && ex_wb_pipe_i.last_op)))
                               );
 
   // Stall ID when WFI is active in EX.

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -244,6 +244,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        sys_en_id;
   logic        sys_mret_insn_id;
   logic        sys_wfi_insn_id;
+  logic        last_op_id;
   logic        csr_en_id;
   csr_opcode_e csr_op_id;
   logic        csr_illegal;
@@ -498,6 +499,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .sys_en_o                     ( sys_en_id                 ),
     .sys_mret_insn_o              ( sys_mret_insn_id          ),
     .sys_wfi_insn_o               ( sys_wfi_insn_id           ),
+    .last_op_o                    ( last_op_id                ),
 
     .csr_en_o                     ( csr_en_id                 ),
     .csr_op_o                     ( csr_op_id                 ),
@@ -826,6 +828,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .csr_en_id_i                    ( csr_en_id              ),
     .csr_op_id_i                    ( csr_op_id              ),
     .sys_wfi_id_i                   ( sys_wfi_insn_id        ),
+    .last_op_id_i                   ( last_op_id             ),
 
     // LSU
     .lsu_split_ex_i                 ( lsu_split_ex           ),

--- a/rtl/cv32e40s_ex_stage.sv
+++ b/rtl/cv32e40s_ex_stage.sv
@@ -188,7 +188,7 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
           branch_target_o   = id_ex_pipe_i.operand_c;
         end
       end
-    end else begin //!SECURE
+    end else begin : regular_branches //!SECURE
       assign branch_decision_o = alu_cmp_result;
       assign branch_target_o   = id_ex_pipe_i.operand_c;
     end

--- a/rtl/cv32e40s_ex_stage.sv
+++ b/rtl/cv32e40s_ex_stage.sv
@@ -166,33 +166,33 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
   end
 
   // Branch handling
-  always_comb begin
-    if (xsecure_ctrl_i.cpuctrl.dataindtiming) begin
-      // Data independent timing enabled, always "take" branch. 
-      branch_decision_o = 1'b1;
+  generate
+    if (SECURE) begin : secure_branches
+      always_comb begin
+        if (xsecure_ctrl_i.cpuctrl.dataindtiming) begin
+          // Data independent timing enabled, always "take" branch.
+          branch_decision_o = 1'b1;
 
-      if (alu_cmp_result) begin
-        // Branch was taken
-        branch_target_o = id_ex_pipe_i.operand_c;
-      end
-      else begin
-        // Branch not taken
-        if (if_id_pipe_i.instr_valid) begin
-          // Jump to PC from ID stage if valid
-          branch_target_o = if_id_pipe_i.pc;
+          if (alu_cmp_result) begin
+            // Branch was taken
+            branch_target_o = id_ex_pipe_i.operand_c;
+          end
+          else begin
+            // ID and EX stage both contain the branch instruction, target addr is in IF.
+            branch_target_o = pc_if_i;
+          end
         end
         else begin
-          // PC in ID not valid, jump to PC from IF stage
-          branch_target_o = pc_if_i;
+          // Data independent timing not enabled
+          branch_decision_o = alu_cmp_result;
+          branch_target_o   = id_ex_pipe_i.operand_c;
         end
       end
+    end else begin //!SECURE
+      assign branch_decision_o = alu_cmp_result;
+      assign branch_target_o   = id_ex_pipe_i.operand_c;
     end
-    else begin
-      // Data independent timing not enabled
-      branch_decision_o = alu_cmp_result;
-      branch_target_o   = id_ex_pipe_i.operand_c;
-    end
-  end
+  endgenerate
 
   ////////////////////////////
   //     _    _    _   _    //
@@ -370,11 +370,15 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
       ex_wb_pipe_o.csr_wdata          <= 32'h00000000;
       ex_wb_pipe_o.xif_en             <= 1'b0;
       ex_wb_pipe_o.xif_meta           <= '0;
+
+      ex_wb_pipe_o.last_op            <= 1'b0;
     end
     else
     begin
       if (ex_valid_o && wb_ready_i) begin
         ex_wb_pipe_o.instr_valid <= 1'b1;
+        ex_wb_pipe_o.last_op     <= id_ex_pipe_i.last_op;
+
         // Deassert rf_we in case of illegal csr instruction or
         // when the first half of a misaligned/split LSU goes to WB.
         // Also deassert if CSR was accepted both by eXtension if and pipeline

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -181,6 +181,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   // MPU
   //////////////////////////////////////////////////////////////////////////////
 
+  // TODO: The prot bits are currently not checked for correctness anywhere
   assign core_trans.addr = prefetch_trans_addr;
   assign core_trans.prot[0] = 1'b0;                     // Transfers from IF stage are instruction transfers
   assign core_trans.prot[2:1] = PRIV_LVL_M;             // Machine mode. TODO: connect to priv_lvl

--- a/rtl/cv32e40s_wb_stage.sv
+++ b/rtl/cv32e40s_wb_stage.sv
@@ -134,7 +134,10 @@ module cv32e40s_wb_stage import cv32e40s_pkg::*;
                      ( ex_wb_pipe_i.lsu_en && lsu_exception)      // LSU instruction had an exception
                     ) && instr_valid;
 
-  assign wb_valid_o = wb_valid;
+  // Only set wb_valid during the last operation of an instruction
+  // TODO: We might want to signal wb_valid for all operations (Zce push/pop for instance), but
+  // this will also require changes in RVFI
+  assign wb_valid_o = wb_valid && ex_wb_pipe_i.last_op;
 
   // Export signal indicating WB stage stalled by load/store
   assign data_stall_o = (ex_wb_pipe_i.lsu_en && !lsu_valid_i) && !wb_valid && instr_valid;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1349,4 +1349,9 @@ typedef struct packed {
     PC_WB
   } pipe_pc_mux_e;
 
+  // Multi operation instructions
+  // Width of ID stage multi op counter
+  parameter MULTI_OP_CNT_WIDTH = 2;
+
+  parameter logic [MULTI_OP_CNT_WIDTH-1:0] JMP_BCH_CYCLES = 2;
 endpackage

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1163,6 +1163,9 @@ typedef struct packed {
   logic         xif_en;           // Instruction has been offloaded via eXtension interface
   xif_meta_t    xif_meta;         // xif meta struct
 
+  // Indicate that this is the last operation of a multi operation instruction
+  logic         last_op;
+
 } id_ex_pipe_t;
 
 // EX/WB pipeline
@@ -1206,6 +1209,9 @@ typedef struct packed {
   // eXtension interface
   logic         xif_en;           // Instruction has been offloaded via eXtension interface
   xif_meta_t    xif_meta;         // xif meta struct
+
+  // Indicate that this is the last operation of a multi operation instruction
+  logic         last_op;
 } ex_wb_pipe_t;
 
 // Performance counter events

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -38,7 +38,7 @@ module cv32e40s_core_sva
   input logic [31:0] mie,
   input dcsr_t       dcsr,
   input              if_id_pipe_t if_id_pipe,
-  input              id_stage_multi_cycle_id_stall,
+  input              id_stage_multi_op_id_stall,
   input logic        id_stage_id_valid,
   input logic        ex_ready,
   input logic        irq_ack, // irq ack output
@@ -261,10 +261,10 @@ always_ff @(posedge clk , negedge rst_ni)
     end
   endgenerate
 
-  // For checking single step, ID stage is used as it contains a 'multi_cycle_id_stall' signal.
+  // For checking single step, ID stage is used as it contains a 'multi_op_id_stall' signal.
   // This makes it easy to count misaligned LSU ins as one instruction instead of two.
   logic inst_taken;
-  assign inst_taken = id_stage_id_valid && ex_ready && !id_stage_multi_cycle_id_stall;
+  assign inst_taken = id_stage_id_valid && ex_ready && !id_stage_multi_op_id_stall;
 
   // Support for single step assertion
   // In case of single step + taken interrupt, the first instruction

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -187,7 +187,7 @@ module cv32e40s_id_stage_sva
   a_mret_self_stall :
     assert property (@(posedge clk) disable iff (!rst_n)
                       (sys_en && sys_mret_insn && last) &&
-                      ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_op) ||
+                      ((id_ex_pipe_o.sys_en && id_ex_pipe_o.sys_mret_insn && !id_ex_pipe_o.last_op) ||
                        (ex_wb_pipe.sys_en && ex_wb_pipe.sys_mret_insn && !ex_wb_pipe.last_op))
                        |-> !ctrl_byp_i.csr_stall)
       else `uvm_error("id_stage", "mret stalls on itself")

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -68,7 +68,7 @@ module cv32e40s_id_stage_sva
   input ctrl_byp_t      ctrl_byp_i,
   input mstatus_t       mstatus_i,
   input logic           xif_insn_accept,
-  input logic           last
+  input logic           last_op
 );
 
     // the instruction delivered to the ID stage should always be valid
@@ -186,9 +186,9 @@ module cv32e40s_id_stage_sva
   // Check that second part of a multicycle mret does not stall on the first part of the same instruction
   a_mret_self_stall :
     assert property (@(posedge clk) disable iff (!rst_n)
-                      (sys_en && sys_mret_insn && last) &&
-                      ((id_ex_pipe_o.sys_en && id_ex_pipe_o.sys_mret_insn && !id_ex_pipe_o.last_op) ||
-                       (ex_wb_pipe.sys_en && ex_wb_pipe.sys_mret_insn && !ex_wb_pipe.last_op))
+                      (sys_en && sys_mret_insn && last_op) &&
+                      ((id_ex_pipe_o.sys_en && id_ex_pipe_o.sys_mret_insn) ||
+                       (ex_wb_pipe.sys_en && ex_wb_pipe.sys_mret_insn))
                        |-> !ctrl_byp_i.csr_stall)
       else `uvm_error("id_stage", "mret stalls on itself")
 

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -61,12 +61,14 @@ module cv32e40s_id_stage_sva
   input csr_opcode_e    csr_op,
   input if_id_pipe_t    if_id_pipe_i,
   input id_ex_pipe_t    id_ex_pipe_o,
+  input ex_wb_pipe_t    ex_wb_pipe,
   input logic           id_ready_o,
   input logic           id_valid_o,
   input ctrl_fsm_t      ctrl_fsm_i,
   input ctrl_byp_t      ctrl_byp_i,
   input mstatus_t       mstatus_i,
-  input logic           xif_insn_accept
+  input logic           xif_insn_accept,
+  input logic           last
 );
 
     // the instruction delivered to the ID stage should always be valid
@@ -180,6 +182,15 @@ module cv32e40s_id_stage_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                      $onehot0({alu_en, div_en, mul_en, csr_en, sys_en, lsu_en, xif_en}))
       else `uvm_error("id_stage", "Multiple functional units enabled")
+
+  // Check that second part of a multicycle mret does not stall on the first part of the same instruction
+  a_mret_self_stall :
+    assert property (@(posedge clk) disable iff (!rst_n)
+                      (sys_en && sys_mret_insn && last) &&
+                      ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_op) ||
+                       (ex_wb_pipe.sys_en && ex_wb_pipe.sys_mret_insn && !ex_wb_pipe.last_op))
+                       |-> !ctrl_byp_i.csr_stall)
+      else `uvm_error("id_stage", "mret stalls on itself")
 
 endmodule // cv32e40s_id_stage_sva
 


### PR DESCRIPTION
Jumps (including mret) and branches are now treated as multi cycle / multi operation instructions.

These instructions will now spend two cycles in ID, EX and WB.
A 'last_op' bit has been added to the id_ex_pipe and ex_wb_pipe, this bit will be low for the
first cycle of jumps and branhces, and high for the second cycle and any other instructions.
wb_valid will only go high for instructions with last_op=1.

- Passes ci_check.

- Not SEC clean.
-- Non-taken branches gets one cycle extra penalty
-- Jumps will get different stall conditions making it non-SEC

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>