### PR TITLE
Fix bug where xsecure csr update would cause circular jumps

### DIFF
--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -646,6 +646,16 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
             ctrl_fsm_o.kill_if = 1'b1;
             ctrl_fsm_o.kill_id = 1'b1;
             ctrl_fsm_o.kill_ex = 1'b1;
+
+            // Jump to PC from oldest valid instruction, excluding WB stage
+            if (id_ex_pipe_i.instr_valid) begin
+              pipe_pc_mux_ctrl = PC_EX;
+            end else if (if_id_pipe_i.instr_valid) begin
+              pipe_pc_mux_ctrl = PC_ID;
+            end else begin
+              pipe_pc_mux_ctrl = PC_IF;
+            end
+
             ctrl_fsm_o.pc_set  = 1'b1;
             ctrl_fsm_o.pc_mux  = PC_WB_PLUS4;
           end else if (branch_taken_ex) begin


### PR DESCRIPTION
After adding the pipeline PC mux, xsecure CSR updates cause a jump to wb.pc (not wb.pc + 4).
Adding logic to control the PC mux.