### PR TITLE
PMP_PMPADDR_RV fix

### DIFF
--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -44,7 +44,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   parameter int          PMP_GRANULARITY                     =  0,
   parameter int          PMP_NUM_REGIONS                     =  0,
   parameter pmpncfg_t    PMP_PMPNCFG_RV[PMP_NUM_REGIONS-1:0] = '{default:PMPNCFG_DEFAULT},
-  parameter [31:0]       PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
+  parameter logic [31:0] PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
   parameter mseccfg_t    PMP_MSECCFG_RV                      = MSECCFG_DEFAULT,
   parameter lfsr_cfg_t   LFSR0_CFG                           = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
   parameter lfsr_cfg_t   LFSR1_CFG                           = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -45,7 +45,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   parameter int          PMP_NUM_REGIONS  = 0,
   parameter int          PMP_GRANULARITY  = 0,
   parameter pmpncfg_t    PMP_PMPNCFG_RV[PMP_NUM_REGIONS-1:0] = '{default:PMPNCFG_DEFAULT},
-  parameter [31:0]       PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
+  parameter logic [31:0] PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
   parameter mseccfg_t    PMP_MSECCFG_RV                      = MSECCFG_DEFAULT,
   parameter lfsr_cfg_t   LFSR0_CFG        = LFSR_CFG_DEFAULT,
   parameter lfsr_cfg_t   LFSR1_CFG        = LFSR_CFG_DEFAULT,
@@ -1491,7 +1491,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
                          .WIDTH      (PMP_ADDR_WIDTH),
                          .MASK       (CSR_PMPADDR_MASK),
                          .SHADOWCOPY (SECURE),
-                         .RESETVALUE (PMP_PMPADDR_RV[i]))
+                         .RESETVALUE (PMP_PMPADDR_RV[i][31-:PMP_ADDR_WIDTH]))
           pmp_addr_csr_i
             (.clk        (clk),
              .rst_n      (rst_n),


### PR DESCRIPTION
Fix type for parameter PMP_PMPADDR_RV and width of reset value used for pmp_addr_csr_i

Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>