### PR TITLE
Merge from E40X til E40S

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -59,7 +59,7 @@ module cv32e40s_wrapper
   parameter [31:0]       PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
   parameter mseccfg_t    PMP_MSECCFG_RV                      = MSECCFG_DEFAULT,
   parameter bit          SMCLIC                       = 0,
-  parameter int          SMCLIC_ID_WIDTH              = 6,
+  parameter int          SMCLIC_ID_WIDTH              = 5,
   parameter int          DBG_NUM_TRIGGERS             = 1,
   parameter int          PMA_NUM_REGIONS              = 0,
   parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}

--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -625,6 +625,8 @@ When an exception or an interrupt is encountered, the core jumps to the correspo
 handler using the content of the ``mtvec[31:7]`` as base address. Both direct mode and vectored mode
 are supported.
 
+The NMI vector location is at index 15 of the machine trap vector table for both direct mode and vectored mode (i.e. at {**mtvec[31:7]**, 5'hF, 2'b00}).
+
 .. _csr-mtvec-smclic:
 
 Machine Trap-Vector Base Address (``mtvec``) - ``SMCLIC`` == 1
@@ -664,18 +666,18 @@ Detailed:
 +-------------+------------+-----------------------------------------------------------------------+
 |   Bit #     |   R/W      |           Description                                                 |
 +=============+============+=======================================================================+
-| 31:8        | WARL       | **BASE[31:8]**: Trap-handler vector table base address.               |
+| 31:7        | WARL       | **BASE[31:7]**: Trap-handler vector table base address.               |
 |             |            | See note below for alignment restrictions.                            |
 +-------------+------------+-----------------------------------------------------------------------+
-| 7:6         | WARL (0x0) | **BASE[7:6]**: Trap-handler vector table base address.                |
+| 6           | WARL (0x0) | **BASE[6]**: Trap-handler vector table base address.                  |
 +-------------+------------+-----------------------------------------------------------------------+
-|  5:0        | R (0x0)    | Reserved. Hardwired to 0.                                             |
+| 5:0         | R (0x0)    | Reserved. Hardwired to 0.                                             |
 +-------------+------------+-----------------------------------------------------------------------+
 
 .. note::
    The ``mtvt`` CSR holds the base address of the trap vector table, aligned on a ``2^(2+SMCLIC_ID_WIDTH)`` bytes or greater
    power-of-two boundary. For example if ``SMCLIC_ID_WIDTH`` = 8, then 256 CLIC interrupts are supported and the trap vector table
-   is aligned to 1024 bytes, and therefore **BASE[9:8]** will be WARL (0x0).
+   is aligned to 1024 bytes, and therefore **BASE[9:7]** will be WARL (0x0).
 
 Machine Status (``mstatush``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_manual/source/exceptions_interrupts.rst
+++ b/docs/user_manual/source/exceptions_interrupts.rst
@@ -106,6 +106,11 @@ In Debug Mode, all interrupts are ignored independent of ``mstatus.MIE`` and the
    Load bus fault, store bus fault,  load parity/checksum fault and store parity/checksum fault are handled as imprecise non-maskable interrupts
    (as opposed to precise exceptions).
 
+.. note::
+
+   The NMI vector location is at index 15 of the machine trap vector table for both direct mode and vectored mode (i.e. at {**mtvec[31:7]**, 5'hF, 2'b00}).
+   The NMI vector location therefore does **not** match its exception code.
+
 Interrupt Interface - ``SMCLIC`` == 1
 -------------------------------------
 
@@ -116,19 +121,21 @@ Interrupts - ``SMCLIC`` == 1
 ----------------------------
 
 Although the [RISC-V-SMCLIC]_ specification supports up to 4096 interrupts, |corev| itself supports at most 1024 interrupts. The
-maximum number of supported CLIC interrupts is equal to ``2^SMCLIC_ID_WIDTH``, which can range from 64 to 1024. The ``SMCLIC_ID_WIDTH`` parameter
+maximum number of supported CLIC interrupts is equal to ``2^SMCLIC_ID_WIDTH``, which can range from 32 to 1024. The ``SMCLIC_ID_WIDTH`` parameter
 also dictates the minimum alignment requirement for the trap vector table to ``2^(2+SMCLIC_ID_WIDTH)`` byte boundaries, see :ref:`csr-mtvt`.
 
 Non Maskable Interrupts
 -----------------------
 
-NMIs update ``mepc``, ``mcause`` and ``mstatus`` similar to regular interrupts. However, as the faults that result in NMIs are imprecise, the contents of ``mepc`` is not guaranteed to point to the instruction after the faulted load or store.
+Non Maskable Interrupts (NMIs) update ``mepc``, ``mcause`` and ``mstatus`` similar to regular interrupts. However, as the faults that result in NMIs are imprecise, the contents of ``mepc`` is not guaranteed to point to the instruction after the faulted load or store.
 
 .. note::
 
    Specifically ``mstatus.mie`` will get cleared to 0 when an (unrecoverable) NMI is taken. [RISC-V-PRIV]_ does not specify the behavior of 
    ``mstatus`` in response to NMIs, see https://github.com/riscv/riscv-isa-manual/issues/756. If this behavior is
    specified at a future date, then we will reconsider our implementation.
+
+The NMI vector location is at index 15 of the machine trap vector table for both direct mode and vectored mode (i.e. {**mtvec[31:7]**, 5'hF, 2'b00}).
 
 An NMI will occur when a load or store instruction experiences a bus fault. The fault resulting in an NMI is handled in an imprecise manner, meaning that the instruction that causes the fault is allowed to retire and the associated NMI is taken afterwards.
 NMIs are never masked by the ``MIE`` bit. NMIs are masked however while in debug mode or while single stepping with ``STEPIE`` = 0 in the ``dcsr`` CSR.
@@ -139,7 +146,6 @@ If an NMI becomes pending while in debug mode as described above, the NMI will b
 
 In case of bufferable stores, the NMI is allowed to become visible an arbitrary time after the instruction retirement. As for the case with debugging, this can cause several instructions to retire
 before the NMI becomes visible to the core.
-
 
 When a data bus fault occurs, the first detected fault will be latched and used for ``mcause`` when the NMI is taken. Any new data bus faults occuring while an NMI is pending will be discarded.
 When the NMI handler is entered, new data bus faults may be latched.

--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -53,7 +53,6 @@ Instantiation Template
       // Configuration
       .boot_addr_i              (),
       .mtvec_addr_i             (),
-      .nmi_addr_i               (),
       .dm_halt_addr_i           (),
       .dm_exception_addr_i      (),
       .mhartid_i                (),
@@ -214,11 +213,6 @@ Interfaces
 |                         |                         |     | address part of :ref:`csr-mtvec`.          |
 |                         |                         |     | Must be 128-byte aligned                   |
 |                         |                         |     | (i.e. ``mtvec_addr_i[6:0]`` = 0).          |
-|                         |                         |     | Do not change after enabling core          |
-|                         |                         |     | via ``fetch_enable_i``                     |
-+-------------------------+-------------------------+-----+--------------------------------------------+
-| ``nmi_addr_i``          | 32                      | in  | ``NMI`` address. Target address for NMIs.  |
-|                         |                         |     | Must be word aligned.                      |
 |                         |                         |     | Do not change after enabling core          |
 |                         |                         |     | via ``fetch_enable_i``                     |
 +-------------------------+-------------------------+-----+--------------------------------------------+

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -521,7 +521,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
           if (USE_DEPRECATED_FEATURE_SET) begin
             ctrl_fsm_o.csr_cause.exception_code = nmi_is_store_q ? DEPRECATED_INT_CAUSE_LSU_STORE_FAULT : DEPRECATED_INT_CAUSE_LSU_LOAD_FAULT;
           end else begin
-          ctrl_fsm_o.csr_cause.exception_code = nmi_is_store_q ? INT_CAUSE_LSU_STORE_FAULT : INT_CAUSE_LSU_LOAD_FAULT;
+            ctrl_fsm_o.csr_cause.exception_code = nmi_is_store_q ? INT_CAUSE_LSU_STORE_FAULT : INT_CAUSE_LSU_LOAD_FAULT;
           end
 
           // Save pc from oldest valid instruction

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -38,7 +38,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   parameter bit          ZC_EXT                              = 0, // todo: remove once fully implemented
   parameter bit          USE_DEPRECATED_FEATURE_SET          = 1, // todo: remove once related features are supported by iss
   parameter bit          SMCLIC                              = 0,
-  parameter int          SMCLIC_ID_WIDTH                     = 6,
+  parameter int          SMCLIC_ID_WIDTH                     = 5,
   parameter int          DBG_NUM_TRIGGERS                    = 1,
   parameter int          PMA_NUM_REGIONS                     = 0,
   parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0]        = '{default:PMA_R_DEFAULT},
@@ -833,8 +833,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .m_irq_enable_o             ( m_irq_enable           ),
     .mepc_o                     ( mepc                   ),
     .mstatus_o                  ( mstatus                ),
- 
-    // PMP CSR's    
+
+    // PMP CSR's
     .csr_pmp_o                  ( csr_pmp                ),
 
     // CSR Parity Error
@@ -859,9 +859,9 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .trigger_match_o            ( trigger_match_if       ),
 
     .priv_lvl_if_ctrl_o         ( priv_lvl_if_ctrl       ),
-    .priv_lvl_lsu_o             ( priv_lvl_lsu           ),    
+    .priv_lvl_lsu_o             ( priv_lvl_lsu           ),
     .priv_lvl_o                 ( priv_lvl               ),
-   
+
     .pc_if_i                    ( pc_if                  )
   );
 
@@ -944,7 +944,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     // Register File read, write back and forwards
     .rf_re_id_i                     ( rf_re_id               ),
     .rf_raddr_id_i                  ( rf_raddr_id            ),
-    
+
     // Fencei flush handshake
     .fencei_flush_ack_i             ( fencei_flush_ack_i     ),
     .fencei_flush_req_o             ( fencei_flush_req_o     ),

--- a/rtl/cv32e40s_pc_check.sv
+++ b/rtl/cv32e40s_pc_check.sv
@@ -48,7 +48,7 @@ module cv32e40s_pc_check import cv32e40s_pkg::*;
   input  logic [31:0] jump_target_id_i,       // Jump target from ID stage
   input  logic [31:0] branch_target_ex_i,     // Branch target from EX stage
   input  logic        branch_decision_ex_i,   // Branch decision from EX stage
-  
+
   // Last_op inputs
   input  logic        last_op_id_i,
   input  logic        last_op_ex_i,
@@ -57,7 +57,7 @@ module cv32e40s_pc_check import cv32e40s_pkg::*;
   input  logic [31:0] mepc_i,
   input  logic [23:0] mtvec_addr_i,
   input  logic [31:0] dpc_i,
-  
+
   // Static core inputs
   input  logic [31:0] boot_addr_i,         // Boot address from toplevel pins
   input  logic [31:0] dm_halt_addr_i,      // Debug address from toplevel pins
@@ -117,7 +117,7 @@ assign ctrl_flow_addr = (pc_mux_q == PC_JUMP)     ? jump_target_id_i      :
                         (pc_mux_q == PC_TRAP_DBD) ? dm_halt_addr_i        :
                         (pc_mux_q == PC_TRAP_DBE) ? dm_exception_addr_i   :
                         (pc_mux_q == PC_TRAP_NMI) ? nmi_addr_i            : // todo: remove when nmi_addr_i is removed
-                        (pc_mux_q == PC_TRAP_EXC) ? {mtvec_addr_i, 8'h0 } : // Also covered by CSR hardening
+                        (pc_mux_q == PC_TRAP_EXC) ? {mtvec_addr_i, 7'h0 } : // Also covered by CSR hardening
                         (pc_mux_q == PC_DRET)     ? dpc_i                 : {boot_addr_i[31:2], 2'b00};
 
 // Choose which address to check vs pc_if, sequential or control flow.
@@ -159,7 +159,7 @@ assign ctrl_flow_untaken_err = jump_mret_untaken_err || branch_untaken_err;
 
 
 
-                                
+
 
 assign ctrl_flow_err = ctrl_flow_taken_err || ctrl_flow_untaken_err;
 

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -590,7 +590,7 @@ typedef struct packed {
   logic        priv_lvl_set;
   privlvl_t    priv_lvl;
 } privlvlctrl_t;
-  
+
 // Machine Vendor ID - OpenHW JEDEC ID is '2 decimal (bank 13)'
 parameter MVENDORID_OFFSET = 7'h2;      // Final byte without parity bit
 parameter MVENDORID_BANK = 25'hC;       // Number of continuation codes
@@ -1035,7 +1035,7 @@ parameter int unsigned PMPNCFG_W            = 8;
 parameter int unsigned CSR_MSECCFG_MML_BIT  = 0;
 parameter int unsigned CSR_MSECCFG_MMWP_BIT = 1;
 parameter int unsigned CSR_MSECCFG_RLB_BIT  = 2;
-  
+
 // PMP access type
 typedef enum logic [1:0] {
   PMP_ACC_EXEC    = 2'b00,
@@ -1207,7 +1207,7 @@ typedef struct packed
   logic [31:0] id;        // ID of offloaded ins
   logic        accepted;  // Was the offloaded instruction accepted or not?
 } xif_meta_t;
-  
+
 // IF/ID pipeline
 typedef struct packed {
   logic        instr_valid;
@@ -1245,7 +1245,7 @@ typedef struct packed {
   // Operands for multiplier and divider
   logic [31:0]  muldiv_operand_a;
   logic [31:0]  muldiv_operand_b;
-  
+
   // CSR
   logic         csr_en;
   csr_opcode_e  csr_op;
@@ -1357,7 +1357,7 @@ typedef struct packed {
   logic                              wb_data_stall;
 } mhpmevent_t;
 
-  
+
 // Controller Bypass outputs
 typedef struct packed {
   op_fw_mux_e   operand_a_fw_mux_sel;   // Operand A forward mux sel
@@ -1421,7 +1421,7 @@ typedef struct packed {
   logic        branch_in_ex;
   logic        branch_in_ex_raw;    // Branch in EX, not qualified with instr_valid
   logic        branch_taken_ex;     // A branch was taken from EX stage
-  
+
   // Performance counter events
   mhpmevent_t  mhpmevent;
 


### PR DESCRIPTION
Plus an additional bugfix where the pc_check module was not updated with regards to changes in mtvec alignment.