### PR TITLE
Width of mtvec into pc_check was wrong.

### DIFF
--- a/rtl/cv32e40s_pc_check.sv
+++ b/rtl/cv32e40s_pc_check.sv
@@ -55,7 +55,7 @@ module cv32e40s_pc_check import cv32e40s_pkg::*;
 
   // CSR inputs
   input  logic [31:0] mepc_i,
-  input  logic [23:0] mtvec_addr_i,
+  input  logic [24:0] mtvec_addr_i,
   input  logic [31:0] dpc_i,
 
   // Static core inputs


### PR DESCRIPTION
Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>