### PR TITLE
Silabs oysteink merge w18

### DIFF
--- a/bhv/cv32e40s_dbg_helper.sv
+++ b/bhv/cv32e40s_dbg_helper.sv
@@ -1,13 +1,13 @@
 // Copyright 2021 Silicon Labs, Inc.
-//   
+//
 // This file, and derivatives thereof are licensed under the
 // Solderpad License, Version 2.0 (the "License");
 // Use of this file means you agree to the terms and conditions
 // of the license and are in full compliance with the License.
 // You may obtain a copy of the License at
-//   
+//
 //     https://solderpad.org/licenses/SHL-2.0/
-//   
+//
 // Unless required by applicable law or agreed to in writing, software
 // and hardware implementations thereof
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,28 +35,37 @@ module cv32e40s_dbg_helper
     input logic                              rf_we,
     input                                    rf_addr_t rf_waddr,
     input logic                              illegal_insn);
-  
-  
+
+
   typedef struct {
     logic [31:0] instr;
     logic        is_compressed;
     opcode_e     opcode;
-    logic [REGFILE_NUM_READ_PORTS-1:0] rf_re;
-    rf_addr_t    rf_raddr[REGFILE_NUM_READ_PORTS];
+    logic     [REGFILE_NUM_READ_PORTS-1:0] rf_re;
+    rf_addr_t [REGFILE_NUM_READ_PORTS-1:0] rf_raddr;
     logic        rf_we;
     rf_addr_t    rf_waddr;
     logic        illegal_insn;
   } dbg_help_t;
-  
+
   dbg_help_t dbg_help;
 
   assign dbg_help.instr         = instr;
   assign dbg_help.is_compressed = is_compressed;
   assign dbg_help.opcode        = opcode_e'(instr[6:0]);
   assign dbg_help.rf_re         = rf_re;
-  assign dbg_help.rf_raddr      = rf_raddr;
   assign dbg_help.rf_we         = rf_we;
   assign dbg_help.rf_waddr      = rf_waddr;
   assign dbg_help.illegal_insn  = illegal_insn;
-  
+
+  // Convert from unpacked to packed array (for verilator support)
+  genvar i;
+  generate for (i=0; i<REGFILE_NUM_READ_PORTS; i++)
+    begin: gen_dbg_rf_raddr
+      assign dbg_help.rf_raddr[i] = rf_raddr[i];
+    end
+  endgenerate
+
+
+
 endmodule

--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -38,8 +38,7 @@ module cv32e40s_rvfi
    input logic                                id_valid_i,
    input logic                                id_ready_i,
    input logic [ 1:0]                         rf_re_id_i,
-   input logic                                sys_en_id_i,
-   input logic                                sys_mret_insn_id_i,
+   input logic                                sys_mret_unqual_id_i,
    input logic                                jump_in_id_i,
    input logic [31:0]                         jump_target_id_i,
    input logic                                is_compressed_id_i,
@@ -756,12 +755,12 @@ module cv32e40s_rvfi
       end
 
       //// ID Stage ////
-      if(id_valid_i && ex_ready_i) begin
+      if (id_valid_i && ex_ready_i) begin
 
         if (jump_in_id_i) begin
           // Predicting mret/jump explicitly instead of using branch_addr_n to
-          // avoid including asynchronous traps and debug reqs in prediction
-          pc_wdata [STAGE_EX] <= (sys_en_id_i && sys_mret_insn_id_i) ? csr_mepc_q_i : jump_target_id_i;
+          // avoid including asynchronous traps and debug reqs in prediction.
+          pc_wdata [STAGE_EX] <= sys_mret_unqual_id_i ? csr_mepc_q_i : jump_target_id_i;
         end else begin
           pc_wdata [STAGE_EX] <= is_compressed_id_i ?  pc_id_i + 2 : pc_id_i + 4;
         end

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -311,7 +311,7 @@ module cv32e40s_wrapper
                 .operand_a_id_i                   (core_i.id_stage_i.operand_a),
                 .operand_b_id_i                   (core_i.id_stage_i.operand_b),
                 .jalr_fw_id_i                     (core_i.id_stage_i.jalr_fw),
-                .alu_en_raw_id_i                  (core_i.alu_en_raw_id),
+                .alu_en_id_i                      (core_i.id_stage_i.alu_en),
                 .alu_jmpr_id_i                    (core_i.alu_jmpr_id),
                 .irq_ack                          (core_i.irq_ack),
                 .*);
@@ -435,8 +435,7 @@ module cv32e40s_wrapper
          .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
          .pc_id_i                  ( core_i.id_stage_i.if_id_pipe_i.pc                                    ),
          .pc_wb_i                  ( core_i.wb_stage_i.ex_wb_pipe_i.pc                                    ),
-         .sys_en_id_i              ( core_i.id_stage_i.sys_en_o                                           ),
-         .sys_mret_insn_id_i       ( core_i.id_stage_i.sys_mret_insn_o                                    ),
+         .sys_mret_unqual_id_i     ( core_i.controller_i.controller_fsm_i.sys_mret_unqual_id              ),
          .jump_in_id_i             ( core_i.controller_i.controller_fsm_i.jump_in_id                      ),
          .jump_target_id_i         ( core_i.id_stage_i.jmp_target_o                                       ),
          .is_compressed_id_i       ( core_i.id_stage_i.if_id_pipe_i.instr_meta.compressed                 ),

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -54,9 +54,8 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   input  logic        alu_en_raw_id_i,
   input  logic        alu_jmp_id_i,               // Jump (JAL, JALR)
   input  logic        alu_jmpr_id_i,              // Jump register (JALR)
-  input  logic        sys_en_id_i,
   input  logic        sys_mret_id_i,
-  input  logic        csr_en_id_i,
+  input  logic        csr_en_raw_id_i,
   input  csr_opcode_e csr_op_id_i,
   input  logic        sys_wfi_id_i,
   input  logic        last_op_id_i,
@@ -150,7 +149,6 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     .id_valid_i                  ( id_valid_i               ),
     .alu_en_id_i                 ( alu_en_id_i              ),
     .alu_jmp_id_i                ( alu_jmp_id_i             ),
-    .sys_en_id_i                 ( sys_en_id_i              ),
     .sys_mret_id_i               ( sys_mret_id_i            ),
 
     // From EX stage
@@ -221,11 +219,9 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     // From ID
     .rf_re_id_i                 ( rf_re_id_i               ),
     .rf_raddr_id_i              ( rf_raddr_id_i            ),
-    .alu_en_raw_id_i            ( alu_en_raw_id_i          ),
     .alu_jmpr_id_i              ( alu_jmpr_id_i            ),
-    .sys_en_id_i                ( sys_en_id_i              ),
     .sys_mret_id_i              ( sys_mret_id_i            ),
-    .csr_en_id_i                ( csr_en_id_i              ),
+    .csr_en_raw_id_i            ( csr_en_raw_id_i          ),
     .csr_op_id_i                ( csr_op_id_i              ),
     .sys_wfi_id_i               ( sys_wfi_id_i             ),
     .last_op_id_i               ( last_op_id_i             ),

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -53,7 +53,6 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   input  if_id_pipe_t if_id_pipe_i,
   input  logic        alu_en_id_i,                // ALU enable
   input  logic        alu_jmp_id_i,               // ALU jump
-  input  logic        sys_en_id_i,
   input  logic        sys_mret_id_i,              // mret in ID stage
 
   // From EX stage
@@ -255,7 +254,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // Blocking on branch_taken_q, as a jump has already been taken
   assign jump_taken_id = jump_in_id && !jump_taken_q;
 
-  assign ctrl_fsm_o.jump_in_id_raw = (alu_jmp_id_i && alu_en_id_i) || (sys_mret_id_i && sys_en_id_i && !debug_mode_q);
+  assign ctrl_fsm_o.jump_in_id_raw = (jmp_unqual_id || sys_mret_unqual_id) && !debug_mode_q;
 
  // todo: RVFI does not use jump_taken_id (which is not in itself an issue); we should have an assertion showing that the target address remains constant during jump_in_id; same remark for branches
 

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -290,11 +290,11 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        alu_en_raw_id;
   logic        alu_jmp_id;
   logic        alu_jmpr_id;
-  logic        sys_en_id;
   logic        sys_mret_insn_id;
   logic        sys_wfi_insn_id;
   logic        last_op_id;
   logic        csr_en_id;
+  logic        csr_en_raw_id;
   csr_opcode_e csr_op_id;
   logic        csr_illegal;
 
@@ -587,12 +587,11 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .alu_en_raw_o                 ( alu_en_raw_id             ),
     .alu_jmp_o                    ( alu_jmp_id                ),
     .alu_jmpr_o                   ( alu_jmpr_id               ),
-    .sys_en_o                     ( sys_en_id                 ),
     .sys_mret_insn_o              ( sys_mret_insn_id          ),
     .sys_wfi_insn_o               ( sys_wfi_insn_id           ),
     .last_op_o                    ( last_op_id                ),
 
-    .csr_en_o                     ( csr_en_id                 ),
+    .csr_en_raw_o                 ( csr_en_raw_id             ),
     .csr_op_o                     ( csr_op_id                 ),
 
     .rf_re_o                      ( rf_re_id                  ),
@@ -951,9 +950,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .alu_en_raw_id_i                ( alu_en_raw_id          ),
     .alu_jmp_id_i                   ( alu_jmp_id             ),
     .alu_jmpr_id_i                  ( alu_jmpr_id            ),
-    .sys_en_id_i                    ( sys_en_id              ),
     .sys_mret_id_i                  ( sys_mret_insn_id       ),
-    .csr_en_id_i                    ( csr_en_id              ),
+    .csr_en_raw_id_i                ( csr_en_raw_id          ),
     .csr_op_id_i                    ( csr_op_id              ),
     .sys_wfi_id_i                   ( sys_wfi_insn_id        ),
     .last_op_id_i                   ( last_op_id             ),

--- a/rtl/cv32e40s_decoder.sv
+++ b/rtl/cv32e40s_decoder.sv
@@ -49,7 +49,6 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
 
   // ALU signals
   output logic          alu_en_o,               // ALU enable
-  output logic          alu_en_raw_o,           // ALU enable without deassert
   output logic          alu_bch_o,              // ALU branch (ALU used for comparison)
   output logic          alu_jmp_o,              // ALU jump (JALR, JALR) (ALU used to compute LR)
   output logic          alu_jmpr_o,             // ALU jump register (JALR) (ALU used to compute LR)
@@ -67,7 +66,8 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
   output logic          div_en_o,               // Perform division
 
   // CSR
-  output logic          csr_en_o,               // Enable access to CSR
+  output logic          csr_en_o,               // CSR enable
+  output logic          csr_en_raw_o,           // CSR enable without deassert
   output csr_opcode_e   csr_op_o,               // Operation to perform on CSR
   input  mstatus_t      mstatus_i,              // Current mstatus
 
@@ -87,7 +87,10 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
   output imm_b_mux_e    imm_b_mux_sel_o,        // Immediate selection for operand b
   output bch_jmp_mux_e  bch_jmp_mux_sel_o,      // Branch / jump target selection
 
-  input  ctrl_fsm_t     ctrl_fsm_i              // Control signal from controller_fsm
+  input  ctrl_fsm_t     ctrl_fsm_i,              // Control signal from controller_fsm,
+
+  // Raw outputs for pc_check todo: can we rewrite pc_check to avoid them?
+  output logic          alu_en_raw_o
 );
 
   // write enable/request control
@@ -225,6 +228,7 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
   // Suppress special instruction/illegal instruction bits
   assign illegal_insn_o = deassert_we_i ? 1'b0 : decoder_ctrl_mux.illegal_insn;
 
-  assign alu_en_raw_o = alu_en;
+  assign csr_en_raw_o = csr_en;
 
+  assign alu_en_raw_o = alu_en;
 endmodule // cv32e40s_decoder

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -73,11 +73,10 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   output logic        alu_jmp_o,        // Jump (JAL, JALR)
   output logic        alu_jmpr_o,       // Jump register (JALR)
 
-  output logic        sys_en_o,
   output logic        sys_mret_insn_o,
   output logic        sys_wfi_insn_o,
   output logic        last_op_o,
-  output logic        csr_en_o,
+  output logic        csr_en_raw_o,
   output csr_opcode_e csr_op_o,
 
   // RF interface -> controller
@@ -146,6 +145,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
   // CSR
   logic                 csr_en;
+  logic                 csr_en_raw;
   csr_opcode_e          csr_op;
 
   // SYS
@@ -209,7 +209,6 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
   assign instr_valid = if_id_pipe_i.instr_valid && !ctrl_fsm_i.kill_id && !ctrl_fsm_i.halt_id;
 
-  assign sys_en_o = sys_en;
   assign sys_mret_insn_o = sys_mret_insn;
   assign sys_wfi_insn_o  = sys_wfi_insn;
 
@@ -451,6 +450,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
     // CSR
     .csr_en_o                        ( csr_en                    ),
+    .csr_en_raw_o                    ( csr_en_raw                ),
     .csr_op_o                        ( csr_op                    ),
     .mstatus_i                       ( mstatus_i                 ),
 
@@ -704,7 +704,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   assign alu_jmp_o    = alu_jmp;
   assign alu_jmpr_o   = alu_jmpr;
 
-  assign csr_en_o = csr_en;
+  assign csr_en_raw_o = csr_en_raw;
   assign csr_op_o = csr_op;
 
   assign last_op_o = last_op;

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -34,7 +34,7 @@ module cv32e40s_core_sva
   input logic        rst_ni,
 
   input ctrl_fsm_t   ctrl_fsm,
-  input logic [10:0]  exc_cause,
+  input logic [10:0] exc_cause,
   input logic [31:0] mie,
   input logic [31:0] mip,
   input dcsr_t       dcsr,
@@ -98,7 +98,7 @@ module cv32e40s_core_sva
   input logic          rf_we_wb,
 
   input logic        alu_jmpr_id_i,
-  input logic        alu_en_raw_id_i,
+  input logic        alu_en_id_i,
 
 
   // probed controller signals
@@ -146,7 +146,7 @@ end else begin
   property p_irq_enabled_0;
     @(posedge clk) disable iff (!rst_ni)
     (ctrl_fsm.pc_set && (ctrl_fsm.pc_mux == PC_TRAP_IRQ)) |->
-    (mie[exc_cause] && ((priv_lvl == PRIV_LVL_M) ? cs_registers_mstatus_q.mie : 1'b1));
+    (mie[exc_cause] && ((priv_lvl == PRIV_LVL_M) ? (cs_registers_mstatus_q.mie && (exc_cause[10:5] == 6'b0)) : 1'b1));
   endproperty
 
   a_irq_enabled_0 : assert property(p_irq_enabled_0) else `uvm_error("core", "Assertion a_irq_enabled_0 failed")
@@ -536,7 +536,7 @@ end
     logic [31:0] opa;
     @(posedge clk) disable iff (!rst_ni)
     (id_stage_id_valid && ex_ready && (alu_op_a_mux_sel_id_i == OP_A_REGA_OR_FWD) && (ctrl_byp.operand_a_fw_mux_sel == SEL_FW_EX), opa=operand_a_id_i)
-    |=> (opa == rf_wdata_wb) && (rf_we_wb || (ctrl_fsm.kill_id || ctrl_fsm.halt_id));
+    |=> (opa == rf_wdata_wb) && (rf_we_wb || (ctrl_fsm.kill_ex || ctrl_fsm.halt_ex));
   endproperty
 
   a_opa_fwd_ex: assert property (p_opa_fwd_ex)
@@ -546,7 +546,7 @@ end
   property p_opa_fwd_wb;
     @(posedge clk) disable iff (!rst_ni)
     (id_stage_id_valid && ex_ready && (alu_op_a_mux_sel_id_i == OP_A_REGA_OR_FWD) && (ctrl_byp.operand_a_fw_mux_sel == SEL_FW_WB))
-    |-> (operand_a_id_i == rf_wdata_wb) && (rf_we_wb || (ctrl_fsm.kill_id || ctrl_fsm.halt_id));
+    |-> (operand_a_id_i == rf_wdata_wb) && rf_we_wb;
   endproperty
 
   a_opa_fwd_wb: assert property (p_opa_fwd_wb)
@@ -557,7 +557,7 @@ end
     logic [31:0] opb;
     @(posedge clk) disable iff (!rst_ni)
     (id_stage_id_valid && ex_ready && (alu_op_b_mux_sel_id_i == OP_B_REGB_OR_FWD) && (ctrl_byp.operand_b_fw_mux_sel == SEL_FW_EX), opb=operand_b_id_i)
-    |=> (opb == rf_wdata_wb) && (rf_we_wb || (ctrl_fsm.kill_id || ctrl_fsm.halt_id));
+    |=> (opb == rf_wdata_wb) && (rf_we_wb || (ctrl_fsm.kill_ex || ctrl_fsm.halt_ex));
   endproperty
 
   a_opb_fwd_ex: assert property (p_opb_fwd_ex)
@@ -567,7 +567,7 @@ end
   property p_opb_fwd_wb;
     @(posedge clk) disable iff (!rst_ni)
     (id_stage_id_valid && ex_ready && (alu_op_b_mux_sel_id_i == OP_B_REGB_OR_FWD) && (ctrl_byp.operand_b_fw_mux_sel == SEL_FW_WB))
-    |-> (operand_b_id_i == rf_wdata_wb) && (rf_we_wb || (ctrl_fsm.kill_id || ctrl_fsm.halt_id));
+    |-> (operand_b_id_i == rf_wdata_wb) && rf_we_wb;
   endproperty
 
   a_opb_fwd_wb: assert property (p_opb_fwd_wb)
@@ -576,7 +576,7 @@ end
   // Check that data forwarded from WB to a JALR instruction in ID is actully written to the RF
   property p_jalr_fwd;
     @(posedge clk) disable iff (!rst_ni)
-    (alu_jmpr_id_i && alu_en_raw_id_i) && (ctrl_byp.jalr_fw_mux_sel == SELJ_FW_WB) && !ctrl_byp.jalr_stall
+    (alu_jmpr_id_i && alu_en_id_i && if_id_pipe.instr_valid) && (ctrl_byp.jalr_fw_mux_sel == SELJ_FW_WB) && !ctrl_byp.jalr_stall
     |->
     (jalr_fw_id_i == rf_wdata_wb) && (rf_we_wb || (ctrl_fsm.kill_id || ctrl_fsm.halt_id));
   endproperty

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -71,11 +71,6 @@ module cv32e40s_id_stage_sva
   input logic           last_op
 );
 
-    // the instruction delivered to the ID stage should always be valid
-    a_valid_instr :
-      assert property (@(posedge clk)
-                       (if_id_pipe_i.instr_valid & (~if_id_pipe_i.illegal_c_insn)) |-> (!$isunknown(instr)) )
-        else `uvm_error("id_stage", $sformatf("%t, Instruction is valid, but has at least one X", $time));
 /* todo: check and fix/remove
       // Check that instruction after taken branch is flushed (more should actually be flushed, but that is not checked here)
       // and that EX stage is ready to receive flushed instruction immediately

--- a/sva/cv32e40s_register_file_sva.sv
+++ b/sva/cv32e40s_register_file_sva.sv
@@ -66,7 +66,7 @@ module cv32e40s_register_file_sva
         a_check_rdata_source_ecc_helper:
 
           assert property (@(posedge clk) disable iff (!rst_n)
-                           (rdata_o[rf_rp] inside mem_gated))
+                           (rdata_o[rf_rp] inside {mem_gated}))
             else `uvm_error("register_file", "Rdata not in memory")
 
         // Check read port ECC


### PR DESCRIPTION
Partly merge from CV32E40X.

Merged at the point where jumps and mrets were no longer qualified with alu_en/sys_en in the controller. This change breaks the E40S' handling of privilege level. Further merge PRs will come after this one to get in sync with CV32E40X and fix the issue with unqualified jumps and mrets.

Not SEC clean