### PR TITLE
Silabs oysteink w18 m3

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -314,6 +314,11 @@ module cv32e40s_wrapper
                 .alu_en_id_i                      (core_i.id_stage_i.alu_en),
                 .alu_jmpr_id_i                    (core_i.alu_jmpr_id),
                 .irq_ack                          (core_i.irq_ack),
+                .sys_mret_unqual_id_bypass        (core_i.controller_i.bypass_i.sys_mret_unqual_id),
+                .jmpr_unqual_id_bypass            (core_i.controller_i.bypass_i.jmpr_unqual_id),
+                .mret_self_stall_bypass           (core_i.controller_i.bypass_i.mret_self_stall),
+                .jumpr_self_stall_bypass          (core_i.controller_i.bypass_i.jumpr_self_stall),
+                .last_op_id_i                     (core_i.id_stage_i.last_op),
                 .*);
 
   bind cv32e40s_sleep_unit:

--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -615,7 +615,7 @@ Detailed:
 +---------+------------------+---------------------------------------------------------------------------------------------------------------+
 | 6:2     | WARL (0x0)       | **BASE[6:2]**: Trap-handler base address, always aligned to 128 bytes. ``mtvec[6:2]`` is hardwired to 0x0.    |
 +---------+------------------+---------------------------------------------------------------------------------------------------------------+
-| 1:0     | WARL (0x0, 0x1)  | **MODE[0]**: Interrupt handling mode. 0x0 = non-vectored basic mode, 0x1 = vectored basic mode.               |
+| 1:0     | WARL (0x0, 0x1)  | **MODE**: Interrupt handling mode. 0x0 = non-vectored basic mode, 0x1 = vectored basic mode.                  |
 +---------+------------------+---------------------------------------------------------------------------------------------------------------+
 
 The initial value of ``mtvec`` is equal to {**mtvec_addr_i[31:7]**, 5'b0, 2'b01}.

--- a/docs/user_manual/source/load_store_unit.rst
+++ b/docs/user_manual/source/load_store_unit.rst
@@ -162,5 +162,6 @@ The write buffer (when not full) allows |corev| to proceed executing instruction
 Bus transfers will occur in program order, no matter if transfers are bufferable and non-bufferable.
 Transactions in the write buffer must be completed before the |corev| is able to:
  
- * Retire a fence instruction
+ * Retire a ``fence`` instruction
+ * Retire a ``fence.i`` instruction
  * Enter SLEEP mode

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -54,6 +54,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   input  logic        alu_en_raw_id_i,
   input  logic        alu_jmp_id_i,               // Jump (JAL, JALR)
   input  logic        alu_jmpr_id_i,              // Jump register (JALR)
+  input  logic        sys_en_id_i,
   input  logic        sys_mret_id_i,
   input  logic        csr_en_raw_id_i,
   input  csr_opcode_e csr_op_id_i,
@@ -147,9 +148,10 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     .if_id_pipe_i                ( if_id_pipe_i             ),
     .id_ready_i                  ( id_ready_i               ),
     .id_valid_i                  ( id_valid_i               ),
-    .alu_en_id_i                 ( alu_en_id_i              ),
     .alu_jmp_id_i                ( alu_jmp_id_i             ),
     .sys_mret_id_i               ( sys_mret_id_i            ),
+    .alu_en_id_i                 ( alu_en_id_i              ),
+    .sys_en_id_i                 ( sys_en_id_i              ),
 
     // From EX stage
     .id_ex_pipe_i                ( id_ex_pipe_i             ),

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -147,19 +147,27 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   // Detect if a secure mret has its last phase (2/2) in ID while the first is in EX or WB.
   // Used to avoid csr_stall in the case where an mret would stall on itself.
   // Using unqualified sys_mret_unqual_id and qualified sys_en/sys_mret_insn from EX and WB.
-  // Using qualified or unqualified does not matter for the value of the self_stall.
+  // Using qualified or unqualified from ID does not matter for the value of the self_stall (assert in core_sva).
   // ctrl_byp_o.deassert_we needs to be 1 for the sys_en to be deasserted, and this cannot
   // happen for the last part (ID) if it didn't already happen to the first part (EX or WB).
-  assign mret_self_stall = (sys_mret_unqual_id && last_op_id_i) && // MRET 2/2 in ID
-                           ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_op) || // mret 1/2 in EX
-                            (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && !ex_wb_pipe_i.last_op));  // mret 1/2 in WB
+  //
+  // Last line excludes setting the self stall signal in case a last part of an mret is in EX stage.
+  // - Last part of mret in EX means any mret in ID must a different mret instruction.
+  // - This mret must then be flagged as faulted (deassert_we=1) for it to have last_op_id_i set. Any csr_stall will then be active, although
+  // - the instruction will not do any side effects and eventually take an exception when it reaches WB.
+  assign mret_self_stall = ((sys_mret_unqual_id && last_op_id_i) && // MRET 2/2 in ID
+                           ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_op && id_ex_pipe_i.instr_valid) ||    // mret 1/2 in EX
+                            (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && !ex_wb_pipe_i.last_op && ex_wb_pipe_i.instr_valid))) &&  // mret 1/2 in WB
+                            !(id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && id_ex_pipe_i.last_op && id_ex_pipe_i.instr_valid);
+
 
   // Detect if a jumpr instruction is stalling on itself (Can only happen if the last part is in ID and the first in EX)
   // Any stall due to first part being in WB would be allowed to forward to ID.
   // ctrl_byp_o.deassert_we needs to be 1 for the alu_en to be deasserted, and this cannot
   // happen for the last part (ID) if it didn't already happen to the first part (EX or WB).
+  // Using unqualified or qualified jumpr get the same result. (Assert in core_sva)
   assign jumpr_self_stall = (jmpr_unqual_id && last_op_id_i) &&
-                            ((id_ex_pipe_i.alu_jmp && id_ex_pipe_i.alu_en && !id_ex_pipe_i.last_op));
+                            ((id_ex_pipe_i.alu_jmp && id_ex_pipe_i.alu_en && !id_ex_pipe_i.last_op && id_ex_pipe_i.instr_valid));
 
 
   // Stall ID when WFI is active in EX.

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -144,13 +144,20 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
                               (ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.csr_en || (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn)))
                               );
 
-  // Detect if an a secure mret has its last phase (2/2) in ID while the first is in EX or WB.
+  // Detect if a secure mret has its last phase (2/2) in ID while the first is in EX or WB.
+  // Used to avoid csr_stall in the case where an mret would stall on itself.
+  // Using unqualified sys_mret_unqual_id and qualified sys_en/sys_mret_insn from EX and WB.
+  // Using qualified or unqualified does not matter for the value of the self_stall.
+  // ctrl_byp_o.deassert_we needs to be 1 for the sys_en to be deasserted, and this cannot
+  // happen for the last part (ID) if it didn't already happen to the first part (EX or WB).
   assign mret_self_stall = (sys_mret_unqual_id && last_op_id_i) && // MRET 2/2 in ID
                            ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_op) || // mret 1/2 in EX
                             (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && !ex_wb_pipe_i.last_op));  // mret 1/2 in WB
 
   // Detect if a jumpr instruction is stalling on itself (Can only happen if the last part is in ID and the first in EX)
   // Any stall due to first part being in WB would be allowed to forward to ID.
+  // ctrl_byp_o.deassert_we needs to be 1 for the alu_en to be deasserted, and this cannot
+  // happen for the last part (ID) if it didn't already happen to the first part (EX or WB).
   assign jumpr_self_stall = (jmpr_unqual_id && last_op_id_i) &&
                             ((id_ex_pipe_i.alu_jmp && id_ex_pipe_i.alu_en && !id_ex_pipe_i.last_op));
 

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -290,6 +290,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        alu_en_raw_id;
   logic        alu_jmp_id;
   logic        alu_jmpr_id;
+  logic        sys_en_id;
   logic        sys_mret_insn_id;
   logic        sys_wfi_insn_id;
   logic        last_op_id;
@@ -596,6 +597,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     .csr_en_raw_o                 ( csr_en_raw_id             ),
     .csr_op_o                     ( csr_op_id                 ),
+    .sys_en_o                     ( sys_en_id                 ),
 
     .rf_re_o                      ( rf_re_id                  ),
     .rf_raddr_o                   ( rf_raddr_id               ),
@@ -953,6 +955,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .alu_en_raw_id_i                ( alu_en_raw_id          ),
     .alu_jmp_id_i                   ( alu_jmp_id             ),
     .alu_jmpr_id_i                  ( alu_jmpr_id            ),
+    .sys_en_id_i                    ( sys_en_id              ),
     .sys_mret_id_i                  ( sys_mret_insn_id       ),
     .csr_en_raw_id_i                ( csr_en_raw_id          ),
     .csr_op_id_i                    ( csr_op_id              ),

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -80,6 +80,8 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   output logic        csr_en_raw_o,
   output csr_opcode_e csr_op_o,
 
+  output logic        sys_en_o,
+
   // RF interface -> controller
   output logic [REGFILE_NUM_READ_PORTS-1:0] rf_re_o,
   output rf_addr_t    rf_raddr_o[REGFILE_NUM_READ_PORTS],
@@ -702,6 +704,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   endgenerate
 
   assign alu_en_o     = alu_en;
+  assign sys_en_o     = sys_en;
   assign alu_en_raw_o = alu_en_raw;
   assign alu_jmp_o    = alu_jmp;
   assign alu_jmpr_o   = alu_jmpr;


### PR DESCRIPTION
Merge from X, taking in reverted controller logic for jumps and mrets.

Small update to self_stall logic for mrets and jumps, and added assertions to check that using qualified or unqualified signals from ID stage when checking for self_stall is equivalent.