### PR TITLE
Renamed "last_op" (last part of secure multi op instruction) to "last…

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -249,7 +249,7 @@ module cv32e40s_wrapper
                               .xif_commit_kill     (1'b0), // todo: remove xif remains
                               .xif_commit_valid    (1'b0), // todo: remove xif remains
 
-                              .last_op_id_i        (core_i.controller_i.last_op_id_i),
+                              .last_sec_op_id_i    (core_i.controller_i.last_sec_op_id_i),
                               .lsu_trans_valid     (core_i.load_store_unit_i.trans_valid),
                               .*);
   bind cv32e40s_cs_registers:        core_i.cs_registers_i              cv32e40s_cs_registers_sva  #(.SMCLIC(SMCLIC)) cs_registers_sva (.*);
@@ -318,7 +318,7 @@ module cv32e40s_wrapper
                 .jmpr_unqual_id_bypass            (core_i.controller_i.bypass_i.jmpr_unqual_id),
                 .mret_self_stall_bypass           (core_i.controller_i.bypass_i.mret_self_stall),
                 .jumpr_self_stall_bypass          (core_i.controller_i.bypass_i.jumpr_self_stall),
-                .last_op_id_i                     (core_i.id_stage_i.last_op),
+                .last_sec_op_id_i                 (core_i.id_stage_i.last_sec_op),
                 .*);
 
   bind cv32e40s_sleep_unit:

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -58,7 +58,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   input  logic        csr_en_raw_id_i,
   input  csr_opcode_e csr_op_id_i,
   input  logic        sys_wfi_id_i,
-  input  logic        last_op_id_i,
+  input  logic        last_sec_op_id_i,
 
   input  id_ex_pipe_t id_ex_pipe_i,
   input  ex_wb_pipe_t ex_wb_pipe_i,
@@ -225,7 +225,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     .csr_en_raw_id_i            ( csr_en_raw_id_i          ),
     .csr_op_id_i                ( csr_op_id_i              ),
     .sys_wfi_id_i               ( sys_wfi_id_i             ),
-    .last_op_id_i               ( last_op_id_i             ),
+    .last_sec_op_id_i           ( last_sec_op_id_i         ),
 
     // From EX
     .csr_counter_read_i         ( csr_counter_read_i       ),

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -293,7 +293,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        sys_en_id;
   logic        sys_mret_insn_id;
   logic        sys_wfi_insn_id;
-  logic        last_op_id;
+  logic        last_sec_op_id;
   logic        csr_en_id;
   logic        csr_en_raw_id;
   csr_opcode_e csr_op_id;
@@ -501,8 +501,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     .branch_decision_ex_i( branch_decision_ex       ),
 
-    .last_op_id_i        ( last_op_id               ),
-    .last_op_ex_i        ( id_ex_pipe.last_op       ),
+    .last_sec_op_id_i    ( last_sec_op_id           ),
+    .last_sec_op_ex_i    ( id_ex_pipe.last_sec_op   ),
     .pc_err_o            ( pc_err_if                ),
 
     .m_c_obi_instr_if    ( m_c_obi_instr_if         ), // Instruction bus interface
@@ -592,7 +592,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .alu_jmpr_o                   ( alu_jmpr_id               ),
     .sys_mret_insn_o              ( sys_mret_insn_id          ),
     .sys_wfi_insn_o               ( sys_wfi_insn_id           ),
-    .last_op_o                    ( last_op_id                ),
+    .last_sec_op_o                ( last_sec_op_id            ),
 
     .csr_en_raw_o                 ( csr_en_raw_id             ),
     .csr_op_o                     ( csr_op_id                 ),
@@ -958,7 +958,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .csr_en_raw_id_i                ( csr_en_raw_id          ),
     .csr_op_id_i                    ( csr_op_id              ),
     .sys_wfi_id_i                   ( sys_wfi_insn_id        ),
-    .last_op_id_i                   ( last_op_id             ),
+    .last_sec_op_id_i               ( last_sec_op_id         ),
 
     // LSU
     .lsu_split_ex_i                 ( lsu_split_ex           ),

--- a/rtl/cv32e40s_ex_stage.sv
+++ b/rtl/cv32e40s_ex_stage.sv
@@ -373,13 +373,13 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
       ex_wb_pipe_o.xif_en             <= 1'b0;
       ex_wb_pipe_o.xif_meta           <= '0;
 
-      ex_wb_pipe_o.last_op            <= 1'b0;
+      ex_wb_pipe_o.last_sec_op        <= 1'b0;
     end
     else
     begin
       if (ex_valid_o && wb_ready_i) begin
         ex_wb_pipe_o.instr_valid <= 1'b1;
-        ex_wb_pipe_o.last_op     <= id_ex_pipe_i.last_op;
+        ex_wb_pipe_o.last_sec_op <= id_ex_pipe_i.last_sec_op;
 
         // Deassert rf_we in case of illegal csr instruction or
         // when the first half of a misaligned/split LSU goes to WB.

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -57,8 +57,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   input  logic          branch_decision_ex_i,   // Current branch decision from EX
 
-  input  logic          last_op_id_i,
-  input  logic          last_op_ex_i,
+  input  logic          last_sec_op_id_i,
+  input  logic          last_sec_op_ex_i,
   output logic          pc_err_o,               // Error signal for the pc checker module
   input  logic [MTVT_ADDR_WIDTH-1:0]   mtvt_addr_i,            // Base address for CLIC vectoring
 
@@ -304,8 +304,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .branch_target_ex_i   ( branch_target_ex_i   ),
     .branch_decision_ex_i ( branch_decision_ex_i ),
 
-    .last_op_id_i         ( last_op_id_i         ),
-    .last_op_ex_i         ( last_op_ex_i         ),
+    .last_sec_op_id_i     ( last_sec_op_id_i     ),
+    .last_sec_op_ex_i     ( last_sec_op_ex_i     ),
 
     .prefetch_is_ptr_i    ( prefetch_is_ptr      ),
 

--- a/rtl/cv32e40s_wb_stage.sv
+++ b/rtl/cv32e40s_wb_stage.sv
@@ -148,7 +148,7 @@ module cv32e40s_wb_stage import cv32e40s_pkg::*;
   // Only set wb_valid during the last operation of an instruction
   // TODO: We might want to signal wb_valid for all operations (Zce push/pop for instance), but
   // this will also require changes in RVFI
-  assign wb_valid_o = wb_valid && ex_wb_pipe_i.last_op;
+  assign wb_valid_o = wb_valid && ex_wb_pipe_i.last_sec_op;
 
   // Export signal indicating WB stage stalled by load/store
   assign data_stall_o = (ex_wb_pipe_i.lsu_en && !lsu_valid_i) && !wb_valid && instr_valid;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1313,7 +1313,7 @@ typedef struct packed {
   xif_meta_t    xif_meta;         // xif meta struct
 
   // Indicate that this is the last operation of a multi operation instruction
-  logic         last_op;
+  logic         last_sec_op;
 
 } id_ex_pipe_t;
 
@@ -1361,7 +1361,7 @@ typedef struct packed {
   xif_meta_t    xif_meta;         // xif meta struct
 
   // Indicate that this is the last operation of a multi operation instruction
-  logic         last_op;
+  logic         last_sec_op;
 } ex_wb_pipe_t;
 
 // Performance counter events

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -82,7 +82,7 @@ module cv32e40s_controller_fsm_sva
   input logic           nmi_is_store_q,
   input logic           nmi_pending_q,
   input dcsr_t          dcsr_i,
-  input logic           last_op_id_i,
+  input logic           last_sec_op_id_i,
   input logic           sys_mret_id_i,
   input logic           csr_wr_in_wb_flush_i,
   input logic           lsu_trans_valid,
@@ -274,9 +274,9 @@ module cv32e40s_controller_fsm_sva
 
   // Detect if the last part of a secure mret is in ID while the first part is in EX or WB
   logic mret_self_stall;
-  assign mret_self_stall = (sys_en_id_i && sys_mret_id_i && last_op_id_i) && // MRET 2/2 in ID
-                      ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_op) || // mret 1/2 in EX
-                       (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && !ex_wb_pipe_i.last_op));  // mret 1/2 in WB
+  assign mret_self_stall = (sys_en_id_i && sys_mret_id_i && last_sec_op_id_i) && // MRET 2/2 in ID
+                      ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_sec_op) || // mret 1/2 in EX
+                       (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && !ex_wb_pipe_i.last_sec_op));  // mret 1/2 in WB
 
   // Check that WFI is stalled in ID if CSR writes (explicit and implicit)
   // are present in EX or WB

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -122,7 +122,7 @@ module cv32e40s_core_sva
   input logic        jmpr_unqual_id_bypass,
   input logic        mret_self_stall_bypass,
   input logic        jumpr_self_stall_bypass,
-  input logic        last_op_id_i
+  input logic        last_sec_op_id_i
   );
 
 
@@ -636,10 +636,10 @@ end
 
 // Helper logic for qualified mret_self_stall, should be the same as unqualified.
 logic mret_self_stall_qual;
-assign mret_self_stall_qual = ((sys_en_id && sys_mret_unqual_id_bypass && last_op_id_i) && // MRET 2/2 in ID
-                              ((id_ex_pipe.sys_en && id_ex_pipe.sys_mret_insn && !id_ex_pipe.last_op && id_ex_pipe.instr_valid) || // mret 1/2 in EX
-                               (ex_wb_pipe.sys_en && ex_wb_pipe.sys_mret_insn && !ex_wb_pipe.last_op && ex_wb_pipe.instr_valid))) &&  // mret 1/2 in WB
-                               !(id_ex_pipe.sys_en && id_ex_pipe.sys_mret_insn && id_ex_pipe.last_op && id_ex_pipe.instr_valid);
+assign mret_self_stall_qual = ((sys_en_id && sys_mret_unqual_id_bypass && last_sec_op_id_i) && // MRET 2/2 in ID
+                              ((id_ex_pipe.sys_en && id_ex_pipe.sys_mret_insn && !id_ex_pipe.last_sec_op && id_ex_pipe.instr_valid) || // mret 1/2 in EX
+                               (ex_wb_pipe.sys_en && ex_wb_pipe.sys_mret_insn && !ex_wb_pipe.last_sec_op && ex_wb_pipe.instr_valid))) &&  // mret 1/2 in WB
+                               !(id_ex_pipe.sys_en && id_ex_pipe.sys_mret_insn && id_ex_pipe.last_sec_op && id_ex_pipe.instr_valid);
 a_mret_self_stall_qual:
   assert property (@(posedge clk) disable iff (!rst_ni)
                   1'b1 |-> (mret_self_stall_qual == mret_self_stall_bypass))
@@ -647,8 +647,8 @@ a_mret_self_stall_qual:
 
 // Helper logic for qualified jumpr_self_stall, should be the same as unqualified.
 logic jumpr_self_stall_qual;
-assign jumpr_self_stall_qual = (alu_en_id_i && jmpr_unqual_id_bypass && last_op_id_i) &&
-                              ((id_ex_pipe.alu_jmp && id_ex_pipe.alu_en && !id_ex_pipe.last_op && id_ex_pipe.instr_valid));
+assign jumpr_self_stall_qual = (alu_en_id_i && jmpr_unqual_id_bypass && last_sec_op_id_i) &&
+                              ((id_ex_pipe.alu_jmp && id_ex_pipe.alu_en && !id_ex_pipe.last_sec_op && id_ex_pipe.instr_valid));
 
 a_jumpr_self_stall_qual:
   assert property (@(posedge clk) disable iff (!rst_ni)

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -68,7 +68,7 @@ module cv32e40s_id_stage_sva
   input ctrl_byp_t      ctrl_byp_i,
   input mstatus_t       mstatus_i,
   input logic           xif_insn_accept,
-  input logic           last_op
+  input logic           last_sec_op
 );
 
 /* todo: check and fix/remove
@@ -181,7 +181,7 @@ module cv32e40s_id_stage_sva
   // Check that second part of a multicycle mret does not stall on the first part of the same instruction
   a_mret_self_stall :
     assert property (@(posedge clk) disable iff (!rst_n)
-                      (sys_en && sys_mret_insn && last_op) &&
+                      (sys_en && sys_mret_insn && last_sec_op) &&
                       ((id_ex_pipe_o.sys_en && id_ex_pipe_o.sys_mret_insn) ||
                        (ex_wb_pipe.sys_en && ex_wb_pipe.sys_mret_insn))
                        |-> !ctrl_byp_i.csr_stall)


### PR DESCRIPTION
…_sec_op".

Precursor to introducing "last_op" (last part of Zc* push/pop etc) in E40X to make merging easier.

SEC clean.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>