### PR TITLE
Added PC hardening for table jumps. Both the pointer fetch and the ju…

### DIFF
--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -326,6 +326,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .mepc_i               ( mepc_i               ),
     .mtvec_addr_i         ( mtvec_addr_i         ),
     .dpc_i                ( dpc_i                ),
+    .jvt_addr_i           ( jvt_addr_i           ),
 
     .boot_addr_i          ( boot_addr_i          ),
     .dm_halt_addr_i       ( dm_halt_addr_i       ),


### PR DESCRIPTION
…mp-to-pointer is hardened.

Formal for design assertions ran for approximately 20 minutes with no failures on pc_check assertions. Longer run will be performed over the weekend.

SEC clean when ZC_EXT=0.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>