### PR TITLE
Reduced profiling infrastructure. Removed support for Zihpm and Zicntr

### DIFF
--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -1250,37 +1250,37 @@ module cv32e40s_rvfi
     end
   endgenerate
 
-  assign ex_csr_rdata_d.cycle                = csr_mhpmcounter_q_l [CSR_CYCLE & 'hF];
+  assign ex_csr_rdata_d.cycle                = csr_mhpmcounter_q_l [CSR_MCYCLE & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
   assign rvfi_csr_rdata_d.cycle              = ex_csr_rdata.cycle;
-  assign rvfi_csr_wdata_d.cycle              = csr_mhpmcounter_n_l [CSR_CYCLE & 'hF];
-  assign rvfi_csr_wmask_d.cycle              = csr_mhpmcounter_we_l[CSR_CYCLE & 'hF];
+  assign rvfi_csr_wdata_d.cycle              = csr_mhpmcounter_n_l [CSR_MCYCLE & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
+  assign rvfi_csr_wmask_d.cycle              = csr_mhpmcounter_we_l[CSR_MCYCLE & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
 
-  assign rvfi_csr_rdata_d.instret            = csr_mhpmcounter_q_l [CSR_INSTRET & 'hF];
-  assign rvfi_csr_wdata_d.instret            = csr_mhpmcounter_n_l [CSR_INSTRET & 'hF];
-  assign rvfi_csr_wmask_d.instret            = csr_mhpmcounter_we_l[CSR_INSTRET & 'hF];
+  assign rvfi_csr_rdata_d.instret            = csr_mhpmcounter_q_l [CSR_MINSTRET & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
+  assign rvfi_csr_wdata_d.instret            = csr_mhpmcounter_n_l [CSR_MINSTRET & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
+  assign rvfi_csr_wmask_d.instret            = csr_mhpmcounter_we_l[CSR_MINSTRET & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
 
   assign rvfi_csr_rdata_d.hpmcounter[ 2:0]   = 'Z;
   assign rvfi_csr_wdata_d.hpmcounter[ 2:0]   = 'Z;  // Does not exist
   assign rvfi_csr_wmask_d.hpmcounter[ 2:0]   = '0;
-  assign rvfi_csr_rdata_d.hpmcounter[31:3]   = csr_mhpmcounter_q_l [31:3];
-  assign rvfi_csr_wdata_d.hpmcounter[31:3]   = csr_mhpmcounter_n_l [31:3];
-  assign rvfi_csr_wmask_d.hpmcounter[31:3]   = csr_mhpmcounter_we_l[31:3];
+  assign rvfi_csr_rdata_d.hpmcounter[31:3]   = csr_mhpmcounter_q_l [31:3]; // todo: No aliasing here (RVFI is bypassing RTL (instead of checking it))
+  assign rvfi_csr_wdata_d.hpmcounter[31:3]   = csr_mhpmcounter_n_l [31:3]; // todo: No aliasing here
+  assign rvfi_csr_wmask_d.hpmcounter[31:3]   = csr_mhpmcounter_we_l[31:3]; // todo: No aliasing here
 
-  assign ex_csr_rdata_d.cycleh               = csr_mhpmcounter_q_h [CSR_CYCLEH & 'hF];
+  assign ex_csr_rdata_d.cycleh               = csr_mhpmcounter_q_h [CSR_MCYCLEH & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
   assign rvfi_csr_rdata_d.cycleh             = ex_csr_rdata.cycleh;
-  assign rvfi_csr_wdata_d.cycleh             = csr_mhpmcounter_n_h [CSR_CYCLEH & 'hF];
-  assign rvfi_csr_wmask_d.cycleh             = csr_mhpmcounter_we_h[CSR_CYCLEH & 'hF];
+  assign rvfi_csr_wdata_d.cycleh             = csr_mhpmcounter_n_h [CSR_MCYCLEH & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
+  assign rvfi_csr_wmask_d.cycleh             = csr_mhpmcounter_we_h[CSR_MCYCLEH & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
 
-  assign rvfi_csr_rdata_d.instreth           = csr_mhpmcounter_q_h [CSR_INSTRETH & 'hF];
-  assign rvfi_csr_wdata_d.instreth           = csr_mhpmcounter_n_h [CSR_INSTRETH & 'hF];
-  assign rvfi_csr_wmask_d.instreth           = csr_mhpmcounter_we_h[CSR_INSTRETH & 'hF];
+  assign rvfi_csr_rdata_d.instreth           = csr_mhpmcounter_q_h [CSR_MINSTRETH & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
+  assign rvfi_csr_wdata_d.instreth           = csr_mhpmcounter_n_h [CSR_MINSTRETH & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
+  assign rvfi_csr_wmask_d.instreth           = csr_mhpmcounter_we_h[CSR_MINSTRETH & 'hF]; // todo: Temporarily using M version; should not have been 'aliased' here (need to fix on X first)
 
   assign rvfi_csr_rdata_d.hpmcounterh[ 2:0]  = 'Z;
   assign rvfi_csr_wdata_d.hpmcounterh[ 2:0]  = 'Z; // Does not exist
   assign rvfi_csr_wmask_d.hpmcounterh[ 2:0]  = '0;
-  assign rvfi_csr_rdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_q_h [31:3];
-  assign rvfi_csr_wdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_n_h [31:3];
-  assign rvfi_csr_wmask_d.hpmcounterh[31:3]  = csr_mhpmcounter_we_h[31:3];
+  assign rvfi_csr_rdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_q_h [31:3]; // todo: No aliasing here (RVFI is bypassing RTL (instead of checking it))
+  assign rvfi_csr_wdata_d.hpmcounterh[31:3]  = csr_mhpmcounter_n_h [31:3]; // todo: No aliasing here
+  assign rvfi_csr_wmask_d.hpmcounterh[31:3]  = csr_mhpmcounter_we_h[31:3]; // todo: No aliasing here
 
   // Machine info
   assign rvfi_csr_rdata_d.mvendorid          = csr_mvendorid_i;

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -466,20 +466,6 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
   // Performance counter events
   assign ctrl_fsm_o.mhpmevent.minstret      = wb_counter_event_gated;
-  assign ctrl_fsm_o.mhpmevent.compressed    = wb_counter_event_gated && ex_wb_pipe_i.instr_meta.compressed;
-  assign ctrl_fsm_o.mhpmevent.jump          = wb_counter_event_gated && ex_wb_pipe_i.alu_jmp_qual;
-  assign ctrl_fsm_o.mhpmevent.branch        = wb_counter_event_gated && ex_wb_pipe_i.alu_bch_qual;
-  assign ctrl_fsm_o.mhpmevent.branch_taken  = wb_counter_event_gated && ex_wb_pipe_i.alu_bch_taken_qual;
-  assign ctrl_fsm_o.mhpmevent.intr_taken    = ctrl_fsm_o.irq_ack;
-  assign ctrl_fsm_o.mhpmevent.data_read     = m_c_obi_data_if.s_req.req && m_c_obi_data_if.s_gnt.gnt && !m_c_obi_data_if.req_payload.we;
-  assign ctrl_fsm_o.mhpmevent.data_write    = m_c_obi_data_if.s_req.req && m_c_obi_data_if.s_gnt.gnt && m_c_obi_data_if.req_payload.we;
-  assign ctrl_fsm_o.mhpmevent.if_invalid    = !if_valid_i && id_ready_i;
-  assign ctrl_fsm_o.mhpmevent.id_invalid    = !id_valid_i && ex_ready_i;
-  assign ctrl_fsm_o.mhpmevent.ex_invalid    = !ex_valid_i && wb_ready_i;
-  assign ctrl_fsm_o.mhpmevent.wb_invalid    = !(wb_valid_i && last_op_wb_i);
-  assign ctrl_fsm_o.mhpmevent.id_jalr_stall = ctrl_byp_i.jalr_stall && !id_valid_i && ex_ready_i;
-  assign ctrl_fsm_o.mhpmevent.id_ld_stall   = ctrl_byp_i.load_stall && !id_valid_i && ex_ready_i;
-  assign ctrl_fsm_o.mhpmevent.wb_data_stall = data_stall_wb_i;
 
   // Mux used to select PC from the different pipeline stages
   always_comb begin

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -143,10 +143,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
   localparam logic [31:0] X_MISA       = 32'h00000000;
   localparam logic [ 1:0] X_ECS_XS     = 2'b00;
 
-  // todo: remove when reducing profiling infrastructure
-  parameter int           NUM_MHPMCOUNTERS  = 1;
-
-
+  // No additional hardware performance counters
+  localparam int          NUM_MHPMCOUNTERS = 0;
 
   // Number of register file read ports
   // Core will only use two, but X_EXT may mandate 2 or 3

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -442,70 +442,6 @@ typedef enum logic[11:0] {
   CSR_MHPMCOUNTER30H = 12'hB9E,
   CSR_MHPMCOUNTER31H = 12'hB9F,
 
-  CSR_CYCLE          = 12'hC00,
-  CSR_INSTRET        = 12'hC02,
-  CSR_HPMCOUNTER3    = 12'hC03,
-  CSR_HPMCOUNTER4    = 12'hC04,
-  CSR_HPMCOUNTER5    = 12'hC05,
-  CSR_HPMCOUNTER6    = 12'hC06,
-  CSR_HPMCOUNTER7    = 12'hC07,
-  CSR_HPMCOUNTER8    = 12'hC08,
-  CSR_HPMCOUNTER9    = 12'hC09,
-  CSR_HPMCOUNTER10   = 12'hC0A,
-  CSR_HPMCOUNTER11   = 12'hC0B,
-  CSR_HPMCOUNTER12   = 12'hC0C,
-  CSR_HPMCOUNTER13   = 12'hC0D,
-  CSR_HPMCOUNTER14   = 12'hC0E,
-  CSR_HPMCOUNTER15   = 12'hC0F,
-  CSR_HPMCOUNTER16   = 12'hC10,
-  CSR_HPMCOUNTER17   = 12'hC11,
-  CSR_HPMCOUNTER18   = 12'hC12,
-  CSR_HPMCOUNTER19   = 12'hC13,
-  CSR_HPMCOUNTER20   = 12'hC14,
-  CSR_HPMCOUNTER21   = 12'hC15,
-  CSR_HPMCOUNTER22   = 12'hC16,
-  CSR_HPMCOUNTER23   = 12'hC17,
-  CSR_HPMCOUNTER24   = 12'hC18,
-  CSR_HPMCOUNTER25   = 12'hC19,
-  CSR_HPMCOUNTER26   = 12'hC1A,
-  CSR_HPMCOUNTER27   = 12'hC1B,
-  CSR_HPMCOUNTER28   = 12'hC1C,
-  CSR_HPMCOUNTER29   = 12'hC1D,
-  CSR_HPMCOUNTER30   = 12'hC1E,
-  CSR_HPMCOUNTER31   = 12'hC1F,
-
-  CSR_CYCLEH         = 12'hC80,
-  CSR_INSTRETH       = 12'hC82,
-  CSR_HPMCOUNTER3H   = 12'hC83,
-  CSR_HPMCOUNTER4H   = 12'hC84,
-  CSR_HPMCOUNTER5H   = 12'hC85,
-  CSR_HPMCOUNTER6H   = 12'hC86,
-  CSR_HPMCOUNTER7H   = 12'hC87,
-  CSR_HPMCOUNTER8H   = 12'hC88,
-  CSR_HPMCOUNTER9H   = 12'hC89,
-  CSR_HPMCOUNTER10H  = 12'hC8A,
-  CSR_HPMCOUNTER11H  = 12'hC8B,
-  CSR_HPMCOUNTER12H  = 12'hC8C,
-  CSR_HPMCOUNTER13H  = 12'hC8D,
-  CSR_HPMCOUNTER14H  = 12'hC8E,
-  CSR_HPMCOUNTER15H  = 12'hC8F,
-  CSR_HPMCOUNTER16H  = 12'hC90,
-  CSR_HPMCOUNTER17H  = 12'hC91,
-  CSR_HPMCOUNTER18H  = 12'hC92,
-  CSR_HPMCOUNTER19H  = 12'hC93,
-  CSR_HPMCOUNTER20H  = 12'hC94,
-  CSR_HPMCOUNTER21H  = 12'hC95,
-  CSR_HPMCOUNTER22H  = 12'hC96,
-  CSR_HPMCOUNTER23H  = 12'hC97,
-  CSR_HPMCOUNTER24H  = 12'hC98,
-  CSR_HPMCOUNTER25H  = 12'hC99,
-  CSR_HPMCOUNTER26H  = 12'hC9A,
-  CSR_HPMCOUNTER27H  = 12'hC9B,
-  CSR_HPMCOUNTER28H  = 12'hC9C,
-  CSR_HPMCOUNTER29H  = 12'hC9D,
-  CSR_HPMCOUNTER30H  = 12'hC9E,
-  CSR_HPMCOUNTER31H  = 12'hC9F,
-
   // Machine information
   CSR_MVENDORID      = 12'hF11,
   CSR_MARCHID        = 12'hF12,
@@ -536,11 +472,10 @@ parameter CSR_MSCRATCHCSW_MASK  = 32'hFFFFFFFF;
 parameter CSR_MSCRATCHCSWL_MASK = 32'hFFFFFFFF;
 parameter CSR_MCLICBASE_MASK    = 32'hFFFFF000;
 parameter CSR_MSCRATCH_MASK     = 32'hFFFFFFFF;
-parameter CSR_CPUCTRL_MASK      = 32'h000F0007;
+parameter CSR_CPUCTRL_MASK      = 32'h000F0007; // todo: will need to become 32'h000F000F
 parameter CSR_PMPNCFG_MASK      = 8'hFF;
 parameter CSR_PMPADDR_MASK      = 32'hFFFFFFFF;
 parameter CSR_MSECCFG_MASK      = 32'h00000007;
-parameter CSR_MCOUNTEREN_MASK   = 32'h00000000;
 parameter CSR_PRV_LVL_MASK      = 32'hFFFFFFFF;
 
 // CSR operations
@@ -607,7 +542,7 @@ parameter MIMPID_MINOR = 4'h0;  // Minor ID
 
 parameter MTVEC_MODE_BASIC  = 2'b01;
 parameter MTVEC_MODE_CLIC   = 2'b11;
-parameter NUM_HPM_EVENTS    =   16;
+parameter NUM_HPM_EVENTS    = 2;
 
 parameter MSTATUS_MIE_BIT      = 3;
 parameter MSTATUS_MPIE_BIT     = 7;
@@ -1373,20 +1308,6 @@ typedef struct packed {
 // Performance counter events
 typedef struct packed {
   logic                              minstret;
-  logic                              compressed;
-  logic                              jump;
-  logic                              branch;
-  logic                              branch_taken;
-  logic                              intr_taken;
-  logic                              data_read;
-  logic                              data_write;
-  logic                              if_invalid;
-  logic                              id_invalid;
-  logic                              ex_invalid;
-  logic                              wb_invalid;
-  logic                              id_ld_stall;
-  logic                              id_jalr_stall;
-  logic                              wb_data_stall;
 } mhpmevent_t;
 
 


### PR DESCRIPTION
Not SEC clean

Removed dedicated hardware performance counter events
Removed Zihpm and Zicntr 
NUM_MHPMCOUNTERS = 0 (mhpmcounter3-31 will be WARL 0)
RVFI needed to be hacked to work around issue in its code that needs to be fixed on the CV32E40X first. Due to this RVFI issue RVFI will still report value for the user mode aliases.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>