### PR TITLE
Merge from CV32E40X

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -387,9 +387,9 @@ module cv32e40s_wrapper
                .PMA_CFG(PMA_CFG))
       write_buffer_sva(.*);
 
-  bind cv32e40x_sequencer:
+  bind cv32e40s_sequencer:
     core_i.if_stage_i.gen_seq.sequencer_i
-      cv32e40x_sequencer_sva
+      cv32e40s_sequencer_sva
         sequencer_sva (.*);
 
 `ifndef FORMAL

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -36,6 +36,7 @@
   `include "cv32e40s_rvfi_sva.sv"
   `include "cv32e40s_pc_check_sva.sv"
   `include "cv32e40s_param_sva.sv"
+  `include "cv32e40s_sequencer_sva.sv"
 `endif
 
 `include "cv32e40s_wrapper.vh"
@@ -386,6 +387,11 @@ module cv32e40s_wrapper
                .PMA_CFG(PMA_CFG))
       write_buffer_sva(.*);
 
+  bind cv32e40x_sequencer:
+    core_i.if_stage_i.gen_seq.sequencer_i
+      cv32e40x_sequencer_sva
+        sequencer_sva (.*);
+
 `ifndef FORMAL
   bind cv32e40s_rvfi:
     rvfi_i
@@ -430,7 +436,7 @@ module cv32e40s_wrapper
          .prefetch_valid_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_valid_o                   ),
          .prefetch_ready_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_ready_i                   ),
          .prefetch_addr_if_i       ( core_i.if_stage_i.prefetch_unit_i.prefetch_addr_o                    ),
-         .prefetch_compressed_if_i ( core_i.if_stage_i.instr_compressed_int                               ),
+         .prefetch_compressed_if_i ( core_i.if_stage_i.instr_compressed                                   ),
          .prefetch_instr_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_instr_o                   ),
 
          // ID Probes

--- a/cv32e40s_manifest.flist
+++ b/cv32e40s_manifest.flist
@@ -49,6 +49,7 @@ ${DESIGN_RTL_DIR}/cv32e40s_m_decoder.sv
 ${DESIGN_RTL_DIR}/cv32e40s_b_decoder.sv
 ${DESIGN_RTL_DIR}/cv32e40s_decoder.sv
 ${DESIGN_RTL_DIR}/cv32e40s_compressed_decoder.sv
+${DESIGN_RTL_DIR}/cv32e40s_sequencer.sv
 ${DESIGN_RTL_DIR}/cv32e40s_alignment_buffer.sv
 ${DESIGN_RTL_DIR}/cv32e40s_prefetch_unit.sv
 ${DESIGN_RTL_DIR}/cv32e40s_mult.sv

--- a/docs/user_manual/source/control_status_registers.rst
+++ b/docs/user_manual/source/control_status_registers.rst
@@ -2137,6 +2137,9 @@ Detailed:
     | 0    | WARL        | **MML**. Machine Mode Lockdown. This is a sticky bit and once set can only be unset due to ``rst_ni`` assertion.                  |
     +------+-------------+-----------------------------------------------------------------------------------------------------------------------------------+
 
+  .. note::
+     ``mseccfg`` is hardwired to 0x0 if ``PMP_NUM_REGIONS`` == 0.
+
   Machine Security Configuration (``mseccfgh``)
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2230,7 +2233,7 @@ Detailed:
     +-------+------------------+---------------------------+
 
   .. note::
-     pmpxcfg is WARL (0x0) if x >= ``PMP_NUM_REGIONS``.
+     ``pmpxcfg`` is WARL (0x0) if x >= ``PMP_NUM_REGIONS``.
 
   .. note::
      If **mseccfg.MML** = 0, then the **R**, **W** and **X**  together form a collective WARL field for which the combinations with **R** = 0 and **W** = 1 are reserved for future use
@@ -2254,7 +2257,8 @@ Detailed:
     | 31:0  | WARL / WARL (0x0)     | ADDRESS[33:2]             |
     +-------+-----------------------+---------------------------+
 
-  pmpaddrx is WARL if x < ``PMP_NUM_REGIONS`` and WARL (0x0) otherwise.
+  .. note::
+     ``pmpaddrx`` is WARL if x < ``PMP_NUM_REGIONS`` and WARL (0x0) otherwise.
 
 .. only:: ZICNTR
 

--- a/docs/user_manual/source/debug.rst
+++ b/docs/user_manual/source/debug.rst
@@ -5,6 +5,12 @@ Debug & Trigger
 
 |corev| offers support for execution-based debug according to [RISC-V-DEBUG]_. The main requirements for the core are described in Chapter 4: RISC-V Debug, Chapter 5: Trigger Module, and Appendix A.2: Execution Based.
 
+.. note::
+
+   As execution based debug is used, the Debug Module (with code entry points defined by ``dm_halt_addr_i`` and ``dm_exception_addr_i``) needs to be located
+   in a memory region that supports code execution. This therefore (at least) requires that the related memory region is marked as Main in the PMA (:ref:`pma`), which
+   is the default behavior if the PMA is deconfigured.
+
 The following list shows the simplified overview of events that occur in the core when debug is requested:
 
  #. Enters Debug Mode
@@ -16,9 +22,9 @@ The following list shows the simplified overview of events that occur in the cor
 
 Debug Mode can be entered by one of the following conditions:
 
- - External debug event using the debug_req_i signal
+ - External debug event using the ``debug_req_i`` signal
  - Trigger Module match event with ``tdata1.action`` set to 1
- - ebreak instruction when not in Debug Mode and when ``dcsr.ebreakm`` == 1 (see :ref:`ebreak_behavior` below)
+ - ebreak instruction when not in Debug Mode and when ``dcsr.EBREAKM`` == 1 (see :ref:`ebreak_behavior` below)
  - ``ebreak`` instruction in user mode when ``dcsr.EBREAKU`` == 1 (see :ref:`ebreak_behavior` below)
 
 A user wishing to perform an abstract access, whereby the user can observe or control a core’s GPR or CSR register from the hart, is done by invoking debug control code to move values to and from internal registers to an externally addressable Debug Module (DM). Using this execution-based debug allows for the reduction of the overall number of debug interface signals.
@@ -26,17 +32,22 @@ A user wishing to perform an abstract access, whereby the user can observe or co
 .. note::
 
    Debug support in |corev| is only one of the components needed to build a System on Chip design with run-control debug support (think "the ability to attach GDB to a core over JTAG").
-   Additionally, a Debug Module and a Debug Transport Module, compliant with the RISC-V Debug Specification, are needed.
+   Additionally, a Debug Module and a Debug Transport Module, compliant with [RISC-V-DEBUG]_, are needed.
 
    A supported open source implementation of these building blocks can be found in the `RISC-V Debug Support for PULP Cores IP block <https://github.com/pulp-platform/riscv-dbg/>`_.
 
-
 The |corev| also supports a Trigger Module to enable entry into Debug Mode on a trigger event with the following features:
 
- - Number of trigger register(s) : Parametrizable 0-4 triggers using parameter ``DBG_NUM_TRIGGERS``.
- - Supported trigger types: instruction address match (Match Control) and exception trigger.
+ - Number of trigger register(s): Parametrizable number of triggers using parameter ``DBG_NUM_TRIGGERS``.
+ - Supported trigger types: Execute/load/store address match (Match Control) and exception trigger.
 
-A trigger match will cause debug entry if ``tdata1.action`` is 1.
+The compare value used to determine an execute address match is the PC of the instruction, i.e. only the lowest virtual address
+of the instruction is used. The compare value(s) used to determine a load/store address match depend(s) on the size of the transferred
+data item as well as the lowest virtual address of the access. A byte load/store for address ``A`` only uses ``A`` as compare value; a
+halfword load/store for address ``A`` uses ``A`` and ``A+1`` as compare values; a word load/store for address ``A`` uses ``A``, ``A+1``,
+``A+2`` and ``A+3`` as compare values.
+
+A trigger match will cause debug entry if ``tdata1.ACTION`` is 1.
 
 The |corev| will not support the optional debug features 10, 11, & 12 listed in Section 4.1 of [RISC-V-DEBUG]_. Specifically, a control transfer instruction's destination location being in or out of the Program Buffer and instructions depending on PC value shall **not** cause an illegal instruction.
 
@@ -90,9 +101,9 @@ The trigger related CSRs (``tselect``, ``tdata1``, ``tdata2``, ``tdata3``, ``tin
 set to a value greater than 0. Further descriptions of these CSRs can be found in :ref:`csr-tselect`, :ref:`csr-tdata1`, :ref:`csr-tdata2`, :ref:`csr-tdata3`,
 :ref:`csr-tinfo`, :ref:`csr-tcontrol` and [RISC-V-DEBUG]_. The optional ``mcontext`` and ``mscontext`` CSRs are not implemented.
 
-If ``DBG_NUM_TRIGGERS`` is zero, access to the trigger registers will result in an illegal instruction exception.
+If ``DBG_NUM_TRIGGERS`` is 0, access to the trigger registers will result in an illegal instruction exception.
 
-The ``tdata1.dmode`` bitfield controls write access permission to the currently selected triggers ``tdata*`` registers. In |corev| this bit is tied to 1, and thus only debug mode is able to write to the trigger registers.
+The ``tdata1.DMODE`` bitfield controls write access permission to the currently selected triggers ``tdata*`` registers. In |corev| this bit is tied to 1, and thus only debug mode is able to write to the trigger registers.
 
 Debug state
 -----------
@@ -136,7 +147,7 @@ The key properties of the debug states are:
 .. _ebreak_behavior:
 
 EBREAK Behavior
---------------------
+---------------
 
 The ``ebreak`` instruction description is distributed across several RISC-V specifications:  [RISC-V-DEBUG]_,
 [RISC-V-PRIV]_, [RISC-V-UNPRIV]_. The following is a summary of the behavior for three common scenarios.
@@ -144,14 +155,14 @@ The ``ebreak`` instruction description is distributed across several RISC-V spec
 Scenario 1 : Enter Exception
 """"""""""""""""""""""""""""
 
-Executing the ``ebreak`` instruction when the core is **not** in Debug Mode and the ``dcsr.ebreakm`` == 0 shall result in the following actions:
+Executing the ``ebreak`` instruction in machine mode when the core is **not** in Debug Mode and ``dcsr.EBREAKM`` == 0 shall result in the following actions:
 
  - The core enters the exception handler routine located at ``mtvec`` (Debug Mode is not entered)
  - ``mepc`` and ``mcause`` are updated
 
 Execution of an ``ebreak`` instruction in user mode when the core is **not** in Debug Mode and ``dcsr.EBREAKU`` == 0 triggers exception entry in a similar manner.
 
-To properly return from the exception, the ebreak handler will need to increment the ``mepc`` to the next instruction. This requires querying the size of the ebreak instruction that was used to enter the exception (16 bit ``c.ebreak`` or 32 bit ``ebreak``).
+To properly return from the exception, the ebreak handler will need to increment the ``mepc`` to the next instruction. This requires querying the size of the ``ebreak`` instruction that was used to enter the exception (16 bit ``c.ebreak`` or 32 bit ``ebreak``).
 
 .. note::
 
@@ -160,7 +171,7 @@ To properly return from the exception, the ebreak handler will need to increment
 Scenario 2 : Enter Debug Mode
 """""""""""""""""""""""""""""
 
-Executing the ``ebreak`` instruction when the core is **not** in Debug Mode and the ``dcsr.ebreakm`` == 1 shall result in the following actions:
+Executing the ``ebreak`` instruction in machine mode when the core is **not** in Debug Mode and ``dcsr.EBREAKM`` == 1 shall result in the following actions:
 
 - The core enters Debug Mode and starts executing debug code located at ``dm_halt_addr_i`` (exception routine not called)
 - ``dpc`` and ``dcsr`` are updated
@@ -171,8 +182,8 @@ Similar to the exception scenario above, the debugger will need to increment the
 
 .. note::
 
-   The default value of ``dcsr.ebreakm`` is 0 and the ``dcsr`` is only accessible in Debug Mode. To enter Debug Mode from ``ebreak``, the user will first need to enter Debug Mode through some other means,
-   such as from the external ``debug_req_i``, and set ``dcsr.ebreakm``.
+   The default value of ``dcsr.EBREAKM`` is 0 and the ``dcsr`` is only accessible in Debug Mode. To enter Debug Mode from ``ebreak``, the user will first need to enter Debug Mode through some other means,
+   such as from the external ``debug_req_i``, and set ``dcsr.EBREAKM``.
 
 Scenario 3 : Exit Program Buffer & Restart Debug Code
 """""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -180,4 +191,4 @@ Scenario 3 : Exit Program Buffer & Restart Debug Code
 Executing the ``ebreak`` instruction when the core is in Debug Mode shall result in the following actions:
 
 - The core remains in Debug Mode and execution jumps back to the beginning of the debug code located at ``dm_halt_addr_i``
-- none of the CSRs are modified
+- None of the CSRs are modified

--- a/docs/user_manual/source/pma.rst
+++ b/docs/user_manual/source/pma.rst
@@ -49,6 +49,10 @@ load access fault (exception code 5). An attempt to perform a modifiable/modifie
    Modifiable transactions are transactions which allow transformations as for example merging or splitting. For example, a misaligned store word instruction that
    is handled as two subword transactions on the data interface is considered to use modified transactions.
 
+.. note::
+   As execution based debug is used, the Debug Module (with code entry points defined by ``dm_halt_addr_i`` and ``dm_exception_addr_i``) needs to be located
+   in a memory region that supports code execution, i.e. in a region defined as main.
+
 Bufferable and Cacheable
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Accesses to regions marked as bufferable (``bufferable=1``) will result in the OBI ``mem_type[0]`` bit being set, except if the access was an instruction fetch, a load, or part of an atomic memory operation. Bufferable stores will utilize the write buffer, see :ref:`Write buffer <write_buffer>`.

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -497,7 +497,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   generate
     if (ZC_EXT) begin : gen_seq
-      cv32e40x_sequencer
+      cv32e40s_sequencer
       sequencer_i
       (
         .clk                ( clk                     ),

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -116,6 +116,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   logic       [31:0] branch_addr_n;
 
   logic              prefetch_valid;
+  logic              prefetch_ready;
   inst_resp_t        prefetch_instr;
   privlvl_t          prefetch_priv_lvl;
   logic              prefetch_is_clic_ptr;
@@ -129,7 +130,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   logic              illegal_c_insn;
 
   inst_resp_t        instr_decompressed;
-  logic              instr_compressed_int;
+  logic              instr_compressed;
 
   // Transaction signals to/from obi interface
   logic              prefetch_resp_valid;
@@ -150,13 +151,22 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   inst_resp_t        dummy_instr;
 
   // Local instr_valid
-  logic instr_valid;
+  logic              instr_valid;
 
   // eXtension interface signals
   logic [X_ID_WIDTH-1:0] xif_id;
 
   // Flag for last operation - used by Zc*
   logic              last_op;
+
+  // ready signal for predecoder, tied to id_ready_i
+  logic              predec_ready;
+
+  // Zc* sequencer signals
+  logic              seq_valid;
+  logic              seq_ready;
+  logic              seq_last;
+  inst_resp_t        seq_instr;
 
   // Fetch address selection
   always_comb
@@ -204,7 +214,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
     .branch_addr_i            ( {branch_addr_n[31:1], 1'b0} ),
 
-    .prefetch_ready_i         ( if_ready                    ),
+    .prefetch_ready_i         ( prefetch_ready              ),
     .prefetch_valid_o         ( prefetch_valid              ),
     .prefetch_instr_o         ( prefetch_instr              ),
     .prefetch_addr_o          ( pc_if_o                     ),
@@ -343,9 +353,27 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   assign instr_valid = (prefetch_valid || dummy_insert) && !ctrl_fsm_i.kill_if && !ctrl_fsm_i.halt_if;
 
   // if_stage ready when killed, otherwise when not halted or if a dummy instruction is inserted.
-  assign if_ready = ctrl_fsm_i.kill_if || (id_ready_i && !dummy_insert && !ctrl_fsm_i.halt_if);
+  assign if_ready = ctrl_fsm_i.kill_if || (seq_ready && predec_ready && !dummy_insert && !ctrl_fsm_i.halt_if);
+  // Local instr_valid when we have valid output from prefetcher
+  // and IF stage is not halted or killed
+  assign instr_valid = prefetch_valid && !ctrl_fsm_i.kill_if && !ctrl_fsm_i.halt_if;
 
-  // if stage valid when local instr_valid is 1
+
+  // if stage valid when local instr_valid=1
+  // Ideally this should be the following:
+  //
+  // assign if_valid_o = (seq_en    && seq_valid    ) ||
+  //                     (predec_en && predec_valid ) && instr_valid;
+  //
+  // seq_en would be an internal signal in the sequencer that is set when a legal push/pop/doublemove is decoded.
+  // seq_valid would then simply be the same as sequencer's valid_i, which is set to instr_valid.
+  //
+  // predec_valid would be tied to 1'b1 (similar to the ALU in the EX stage) as this is a combinatorial unit with
+  // with no handshake to improve timing.
+  // predec_en would also be tied to 1'b1 as the predecoder will produce output for any input
+  //   Legal or illegal compressed, + passthru of uncompressed instructions
+  // In short: Any prefetched instruction (or pointer) will make if_valid_o high
+
   assign if_valid_o = instr_valid;
 
   assign if_busy_o = prefetch_busy;
@@ -354,6 +382,10 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   assign lfsr_shift_o = (if_valid_o && id_ready_i) && dummy_insert;
 
   assign ptr_in_if_o = prefetch_is_clic_ptr || prefetch_is_tbljmp_ptr;
+
+  // Acknowledge prefetcher when IF stage is ready. This factors in seq_ready to avoid ack'ing the
+  // prefetcher in the middle of a Zc sequence.
+  assign prefetch_ready = if_ready;
 
   // Last operation of table jumps are set when the pointer is fed to ID stage
   // tbljmp is set when a cm.jt or cm.jalt is decoded in the compressed decoder.
@@ -396,7 +428,10 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
       if (if_valid_o && id_ready_i) begin
         if_id_pipe_o.instr_valid      <= 1'b1;
         if_id_pipe_o.instr_meta       <= instr_meta_n;
-        if_id_pipe_o.illegal_c_insn   <= dummy_insert ? 1'b0 : illegal_c_insn;
+        // seq_valid implies no illegal instruction, sequencer successfully decoded an instruction.
+        // compressed decoder will still raise illegal_c_insn as it doesn't (currently) recognize Zc push/pop/dmove
+        if_id_pipe_o.illegal_c_insn   <= (seq_valid || dummy_insert) ? 1'b0 : illegal_c_insn;
+
 
         if_id_pipe_o.priv_lvl         <= prefetch_priv_lvl;
         if_id_pipe_o.trigger_match    <= dummy_insert ? 1'b0 : trigger_match_i;
@@ -405,15 +440,16 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
         // No PC update for tablejump pointer, PC of instruction itself is needed later.
         // No update to the meta compressed, as this is used in calculating the link address.
-        //   Any pointer could change instr_compressed_int and cause a wrong link address.
+        //   Any pointer could change instr_compressed and cause a wrong link address.
         // No update to tbljmp flag, we want flag to be high for both operations.
         if (!prefetch_is_tbljmp_ptr) begin
           if_id_pipe_o.pc                    <= pc_if_o;
-          if_id_pipe_o.instr_meta.compressed <= dummy_insert ? 1'b0 : instr_compressed_int;
+          // todo: push/pop*/doublemoves are compressed, how (if at all) should we signal that when we emit uncompressed sequences?
+          if_id_pipe_o.instr_meta.compressed <= dummy_insert ? 1'b0 : instr_compressed;
           if_id_pipe_o.instr_meta.tbljmp     <= tbljmp;
 
           // Only update compressed_instr for compressed instructions
-          if (instr_compressed_int) begin
+          if (instr_compressed) begin
             if_id_pipe_o.compressed_instr      <= prefetch_instr.bus_resp.rdata[15:0];
           end
         end
@@ -428,7 +464,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
           if_id_pipe_o.instr.mpu_status   <= instr_decompressed.mpu_status;
         end else begin
           // Regular instruction, update the whole instr field
-          if_id_pipe_o.instr          <= dummy_insert ? dummy_instr : instr_decompressed;;
+          if_id_pipe_o.instr          <= dummy_insert ? dummy_instr :
+                                        seq_valid     ? seq_instr   : instr_decompressed;
         end
       end else if (id_ready_i) begin
         if_id_pipe_o.instr_valid      <= 1'b0;
@@ -449,10 +486,43 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .mstateen0_i        ( mstateen0_i             ),
     .priv_lvl_i         ( prefetch_priv_lvl       ),
     .instr_o            ( instr_decompressed      ),
-    .is_compressed_o    ( instr_compressed_int    ),
+    .is_compressed_o    ( instr_compressed        ),
     .illegal_instr_o    ( illegal_c_insn          ),
     .tbljmp_o           ( tbljmp_raw              )
   );
+
+  // Setting predec_ready to id_ready_i here instead of passing it through the predecoder.
+  // Predecoder is purely combinatorial and is always ready for new inputs
+  assign predec_ready = id_ready_i;
+
+  generate
+    if (ZC_EXT) begin : gen_seq
+      cv32e40x_sequencer
+      sequencer_i
+      (
+        .clk                ( clk                     ),
+        .rst_n              ( rst_n                   ),
+
+        .instr_i            ( prefetch_instr          ),
+        .instr_is_ptr_i     ( ptr_in_if_o             ),
+
+        .valid_i            ( instr_valid             ),
+        .ready_i            ( id_ready_i              ),
+
+
+        .instr_o            ( seq_instr               ),
+        .valid_o            ( seq_valid               ),
+        .ready_o            ( seq_ready               ),
+        .seq_last_o         ( seq_last                ) // todo: currently not used, will be factored into 'last_op' later
+      );
+    end else begin : gen_no_seq
+      assign seq_valid = 1'b0;
+      assign seq_last = 1'b0;
+      assign seq_instr = '0;
+      assign seq_ready = 1'b1;
+    end
+  endgenerate
+
 
   // tbljmp below is used in calculating 'last_op'. If we have a faulted fetch, the instruction word may be anything
   // (not cleared on faulted fetches). A faulted fetch should not be decoded to anything and thus tbljmp is cleared.

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -354,9 +354,6 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   // if_stage ready when killed, otherwise when not halted or if a dummy instruction is inserted.
   assign if_ready = ctrl_fsm_i.kill_if || (seq_ready && predec_ready && !dummy_insert && !ctrl_fsm_i.halt_if);
-  // Local instr_valid when we have valid output from prefetcher
-  // and IF stage is not halted or killed
-  assign instr_valid = prefetch_valid && !ctrl_fsm_i.kill_if && !ctrl_fsm_i.halt_if;
 
 
   // if stage valid when local instr_valid=1

--- a/rtl/cv32e40s_sequencer.sv
+++ b/rtl/cv32e40s_sequencer.sv
@@ -1,0 +1,350 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Oystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Design Name:    Sequencer                                                  //
+// Project Name:   CV32E40X                                                   //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    Sequencer for Zc push/pop and double move instructions     //
+//                 Inherited from CV32E41P PR#24 and updated to support       //
+//                 Zc spec 0.70.4.
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40x_sequencer
+import cv32e40x_pkg::*;
+ (
+    input  logic       clk,
+    input  logic       rst_n,
+
+    input  inst_resp_t instr_i,          // Instruction from prefetch unit
+    input  logic       instr_is_ptr_i,   // Pointer flag, instr_i does not contain an instruction
+
+    input  logic       valid_i,          // valid input from if stage
+    input  logic       ready_i,          // Downstream is ready (ID stage)
+
+    output inst_resp_t instr_o,          // Output sequenced (32-bit) instruction
+    output logic       valid_o,          // Output is valid - input is valid AND we decode a valid seq instruction
+    output logic       ready_o,          // Sequencer is ready for new inputs
+    output logic       seq_last_o        // Last operation is being output
+  );
+
+  seq_t                instr_cnt_q;        // Count number of emitted uncompressed instructions
+  pushpop_decode_s     decode;             // Struct holding metatdata for current decoded instruction
+  seq_instr_e          seq_instr;          // Type of current decoded instruction
+
+  logic [31:0]         instr;              // Instruction word from prefetcher
+  logic [3:0]          rlist;              // rlist for push/pop*
+
+  // Helper signals to indicate type of instruction
+  logic                seq_load;
+  logic                seq_store;
+  logic                seq_move_a2s;
+
+  // FSM state
+  seq_state_e          seq_state_n;
+  seq_state_e          seq_state_q;
+
+  assign instr = instr_i.bus_resp.rdata;
+  assign rlist = instr[7:4];
+
+  // Count number of instructions emitted and set next state for FSM.
+  always_ff @( posedge clk, negedge rst_n) begin
+    if (!rst_n) begin
+      instr_cnt_q <= '0;
+      seq_state_q <= S_IDLE;
+    end else begin
+      if (valid_o && ready_i) begin
+        if (!seq_last_o) begin
+          instr_cnt_q <= instr_cnt_q + 1'd1;
+        end else begin
+          instr_cnt_q <= '0;
+        end
+
+        seq_state_q <= seq_state_n;
+      end else if (!valid_o) begin
+        // Whenever we have no valid outputs, reset counter to 0.
+        // This is factoring in kill_if and halt_if.
+        instr_cnt_q <= '0;
+        seq_state_q <= seq_state_n;
+      end
+    end
+  end // always_ff
+
+  ///////////////////////////////////
+  // Decode sequenced instructions //
+  ///////////////////////////////////
+  always_comb
+  begin
+    seq_instr    = INVALID_INST;
+    seq_load     = 1'b0;
+    seq_store    = 1'b0;
+    seq_move_a2s = 1'b0;
+    // All sequenced instructions are within C2
+    if (instr[1:0] == 2'b10) begin
+      if (instr[15:13] == 3'b101) begin
+        unique case (instr[12:10])
+          3'b011: begin
+            // rs1 must be different from rs2
+            if (instr[9:7] != instr[4:2]) begin
+              if (instr[6:5] == 2'b11) begin
+                // cm.mva01s
+                seq_instr = MVA01S;
+              end else if (instr[6:5] == 2'b01) begin
+                // cm.mvsa01
+                seq_instr = MVSA01;
+                seq_move_a2s = 1'b1;
+              end
+            end
+          end
+          3'b110: begin
+            if (instr[9:8] == 2'b00) begin
+              // cm.push
+              if (rlist > 3) begin
+                seq_instr = PUSH;
+                seq_store = 1'b1;
+              end
+            end else if (instr[9:8] == 2'b10) begin
+              // cm.pop
+              if (rlist > 3) begin
+                seq_instr = POP;
+                seq_load = 1'b1;
+              end
+            end
+          end
+          3'b111: begin
+            if (instr[9:8] == 2'b00) begin
+              // cm.popretz
+              if (rlist > 3) begin
+                seq_instr = POPRETZ;
+                seq_load = 1'b1;
+              end
+            end else if (instr[9:8] == 2'b10) begin
+              // cm.popret
+              if (rlist > 3) begin
+                seq_instr = POPRET;
+                seq_load = 1'b1;
+              end
+            end
+          end
+          default: begin
+            seq_instr = INVALID_INST;
+          end
+        endcase
+      end // instr[15:13]
+    end // C2
+  end // always_comb
+
+  // Local valid
+  // In principle this is the same as "seq_en && valid_i"
+  //   as the output of the above decode logic is equivalent to seq_en
+  // todo: halting IF stage would imply !valid, can this be an issue?
+  assign valid_o = (seq_instr != INVALID_INST) && !instr_is_ptr_i && valid_i;
+
+
+  // Calculate number of S* registers needed in sequence (push/pop* only)
+  assign decode.registers_saved = pushpop_reg_length(rlist);
+
+  // Calculate stack space needed for the push/pop* registers (including ra)
+  // 16-bit aligned
+  assign decode.stack_adj_base = get_stack_adj_base(rlist);
+
+  // Compute total stack adjustment based on saved registers and additional 16 byte blocks from immediate
+  assign decode.total_stack_adj = decode.stack_adj_base + (instr[3:2] << 4);
+
+  // Calculate the current stack address used for push/pop*
+  always_comb begin : current_stack_adj
+    case (seq_instr)
+      PUSH: begin
+        // Start pushing to -4(SP)
+        decode.current_stack_adj = -{{instr_cnt_q+12'b1}<<2};
+      end
+      POP,POPRET, POPRETZ: begin
+        // Need to account for any extra allocated stack space during cm.push
+        // Rewind with decode.total_stack_adj and then start by popping from -4
+        decode.current_stack_adj = decode.total_stack_adj-12'({instr_cnt_q+5'b1}<<2);
+      end
+      default:
+        decode.current_stack_adj = '0;
+    endcase
+  end
+
+  // Set current sreg number based on sequence counter
+  assign decode.sreg = decode.registers_saved - instr_cnt_q - 4'd1;
+
+  // Generate 32-bit instructions for all sequenced operations
+  always_comb begin : sequencer_state_machine
+    instr_o = instr_i;
+    seq_state_n = seq_state_q;
+    seq_last_o = 1'b0;
+
+    ready_o = 1'b0;
+
+    case (seq_state_q)
+      S_IDLE: begin
+        // First instruction is output here
+        if (seq_load) begin
+          if (decode.registers_saved == 'd1) begin
+            // Exactly one S register popped
+            // lw rd, decode.current_stack_adj(SP)
+            instr_o.bus_resp.rdata = {decode.current_stack_adj,REG_SP,3'b010,sn_to_regnum(decode.sreg),OPCODE_LOAD};
+            // Finished loading the single Sreg, ra next
+            seq_state_n = S_RA;
+          end else if (decode.registers_saved > 'd1) begin
+            // More than one S register popped
+            // lw rd, decode.current_stack_adj(SP)
+            instr_o.bus_resp.rdata = {decode.current_stack_adj,REG_SP,3'b010,sn_to_regnum(decode.sreg),OPCODE_LOAD};
+            // Continue popping Sregs
+            seq_state_n = S_POP;
+          end else begin
+            // No S register popped, pop ra
+            // lw ra, decode.current_stack_adj(SP)
+            instr_o.bus_resp.rdata = {decode.current_stack_adj,REG_SP,3'b010,REG_RA,OPCODE_LOAD};
+            // Finished popping, stack pointer next
+            seq_state_n = S_SP;
+          end
+        end else if (seq_store) begin
+          // Current stack adjustment for the first stores are always -4
+          if (decode.registers_saved == 'd1) begin
+            // Exactly one S register pushed
+            // sw, rs2, -4(sp)
+            instr_o.bus_resp.rdata = {7'b1111111,sn_to_regnum(decode.sreg),5'd2,3'b010,5'b11100,OPCODE_STORE};
+            // Finished pushing, ra next
+            seq_state_n = S_RA;
+          end else if (decode.registers_saved > 'd1) begin
+            // More than one S register pushed
+            // sw, rs2, -4(sp)
+            instr_o.bus_resp.rdata = {7'b1111111,sn_to_regnum(decode.sreg),5'd2,3'b010,5'b11100,OPCODE_STORE};
+            // Continue pushing
+            seq_state_n = S_PUSH;
+          end else begin
+            // No S register pushed
+            // sw, ra, -4(sp)
+            instr_o.bus_resp.rdata = {7'b1111111,REG_RA,5'd2,3'b010,5'b11100,OPCODE_STORE};
+            // Finished pushing, stack pointer next
+            seq_state_n = S_SP;
+          end
+        end else if (seq_move_a2s) begin
+          // addi s*, a0, 0
+          instr_o.bus_resp.rdata = {12'h000, 5'd10, 3'b000, sn_to_regnum(5'(instr[9:7])), OPCODE_OPIMM};
+          seq_state_n = S_DMOVE;
+        end else begin
+          // move s to a
+          // addi a0, s*, 0
+          instr_o.bus_resp.rdata = {12'h000, sn_to_regnum(5'(instr[9:7])), 3'b000, 5'd10, OPCODE_OPIMM};
+          seq_state_n = S_DMOVE;
+        end
+
+      end
+      // todo: Any instruction output while not in S_IDLE should not combinatorially depend on instr_rdata_i
+      S_PUSH: begin
+        // sw rs2, current_stack_adj(sp)
+        instr_o.bus_resp.rdata = {decode.current_stack_adj[11:5],sn_to_regnum(decode.sreg),REG_SP,3'b010,decode.current_stack_adj[4:0],OPCODE_STORE};
+        // Advance FSM when we have saved all s* registers
+        if (instr_cnt_q == decode.registers_saved - 1) begin
+          seq_state_n = S_RA;
+        end
+      end
+      S_POP: begin
+        // lw rd, current_stack_adj(sp)
+        instr_o.bus_resp.rdata = {decode.current_stack_adj,REG_SP,3'b010,sn_to_regnum(decode.sreg),OPCODE_LOAD};
+        // Advance FSM when we have loaded all s* registers
+        if (instr_cnt_q == decode.registers_saved - 1) begin
+          seq_state_n = S_RA;
+        end
+      end
+      S_DMOVE: begin
+        // Second half of double moves
+        if (seq_move_a2s) begin
+          // addi s*, a1, 0
+          instr_o.bus_resp.rdata = {12'h000, 5'd11, 3'b000, sn_to_regnum(5'(instr[4:2])), OPCODE_OPIMM};
+        end else begin
+          // addi a1, s*, 0
+          instr_o.bus_resp.rdata = {12'h000, sn_to_regnum(5'(instr[4:2])), 3'b000, 5'd11, OPCODE_OPIMM};
+        end
+
+        seq_state_n = S_IDLE;
+        ready_o = ready_i;
+        seq_last_o = 1'b1;
+      end
+      S_RA: begin
+        // push pop ra register
+        if (seq_load) begin
+          // lw ra, current_stack_adj(sp)
+          instr_o.bus_resp.rdata = {decode.current_stack_adj,REG_SP,3'b010,REG_RA,OPCODE_LOAD};
+        end else begin
+          // sw ra, current_stack_adj(sp)
+          instr_o.bus_resp.rdata = {decode.current_stack_adj[11:5],REG_RA,REG_SP,3'b010,decode.current_stack_adj[4:0],OPCODE_STORE};
+        end
+
+        seq_state_n = S_SP;
+      end
+      S_SP: begin
+        // Adjust stack pointer
+        if (seq_load) begin
+          // addi sp, sp, total_stack_adj
+          instr_o.bus_resp.rdata = {decode.total_stack_adj,REG_SP,3'b0,REG_SP,OPCODE_OPIMM};
+        end else begin
+          // addi sp, sp, -total_stack_adj
+          instr_o.bus_resp.rdata = {-decode.total_stack_adj,REG_SP,3'b0,REG_SP,OPCODE_OPIMM};
+        end
+
+
+        if (seq_instr == POPRETZ) begin
+          seq_state_n = S_A0;
+        end else if (seq_instr == POPRET) begin
+          seq_state_n = S_RET;
+        end else begin
+          seq_state_n = S_IDLE;
+          ready_o = ready_i;
+          seq_last_o = 1'b1;
+        end
+      end
+      S_A0: begin
+        // Clear a0 for popretz
+        // addi ra, x0, 0
+        instr_o.bus_resp.rdata = {12'h000,5'd0,3'b0,5'd10,OPCODE_OPIMM};
+
+        seq_state_n = S_RET;
+      end
+      S_RET: begin
+        // return for popret/popretz
+        // jalr x0, 0(ra)
+        instr_o.bus_resp.rdata = {12'b0,REG_RA,3'b0,5'b0,OPCODE_JALR};
+
+        seq_state_n = S_IDLE;
+        ready_o = ready_i;
+        seq_last_o = 1'b1;
+      end
+    endcase
+
+    // If there is no valid output, default to ready_o and IDLE state.
+    // valid_i is already baked into valid_o and thus this takes effect on kill_if and halt_if
+    if (!valid_o) begin
+      ready_o = 1'b1;
+      seq_state_n = S_IDLE;
+    end
+  end
+
+
+endmodule

--- a/rtl/cv32e40s_sequencer.sv
+++ b/rtl/cv32e40s_sequencer.sv
@@ -22,7 +22,7 @@
 // Engineer:       Oystein Knauserud - oystein.knauserud@silabs.com           //
 //                                                                            //
 // Design Name:    Sequencer                                                  //
-// Project Name:   CV32E40X                                                   //
+// Project Name:   CV32E40S                                                   //
 // Language:       SystemVerilog                                              //
 //                                                                            //
 // Description:    Sequencer for Zc push/pop and double move instructions     //
@@ -31,8 +31,8 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-module cv32e40x_sequencer
-import cv32e40x_pkg::*;
+module cv32e40s_sequencer
+import cv32e40s_pkg::*;
  (
     input  logic       clk,
     input  logic       rst_n,

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1459,4 +1459,106 @@ typedef struct packed {
   parameter MULTI_OP_CNT_WIDTH = 2;
 
   parameter logic [MULTI_OP_CNT_WIDTH-1:0] JMP_BCH_CYCLES = 2;
+
+  //////////////////
+  // Zc Sequencer //
+  //////////////////
+
+  typedef logic [4:0] regnum_t;
+  typedef logic [3:0] seq_t;    // Max length is 16 for POPRETZ, counter limit is then 15.
+
+  localparam REG_ZERO = 5'd0;
+  localparam REG_RA = 5'd1;
+  localparam REG_SP = 5'd2;
+
+  typedef enum logic [3:0] {
+    INVALID_INST,
+    PUSH,
+    POP,
+    POPRET,
+    POPRETZ,
+    MVA01S,
+    MVSA01
+  } seq_instr_e;
+
+  typedef enum logic [3:0] {
+    R_NONE    = 4'd0,
+    RA_S0     = 4'd1,
+    RA_S0_S1  = 4'd2,
+    RA_S0_S2  = 4'd3,
+    RA_S0_S3  = 4'd4,
+    RA_S0_S4  = 4'd5,
+    RA_S0_S5  = 4'd6,
+    RA_S0_S6  = 4'd7,
+    RA_S0_S7  = 4'd8,
+    RA_S0_S8  = 4'd9,
+    RA_S0_S9  = 4'd10,
+    RA_S0_S11 = 4'd12
+  } pushpop_rlist_e;
+
+
+  typedef struct packed {
+    logic [11:0]    stack_adj_base;        // Stack adjustment based on space needed by register list
+    pushpop_rlist_e registers_saved;       // Number of s-registers saved (excluding ra)
+    logic [11:0]    total_stack_adj;       // Total stack adjustment (register space + extra blocks)
+    logic [11:0]    current_stack_adj;     // Current stack adjustment for use in sequence
+    regnum_t        sreg;                  // Current s-register being pushed/popped
+  } pushpop_decode_s;
+
+
+  // Map any of S0-S11 to X-registers
+  function automatic regnum_t sn_to_regnum(regnum_t snum);
+    case (snum)
+      0, 1:    sn_to_regnum = regnum_t'({(snum[3:1] != 3'd0), 1'b1, snum[2:0]});
+      default: sn_to_regnum = regnum_t'({(snum[3:1] != 3'd0), snum[3], snum[2:0]});
+    endcase
+  endfunction
+
+  // Set stack adjustment base based on rlist as suggested in Zc spec 0.70.4
+  function automatic logic [11:0] get_stack_adj_base(logic [3:0] rlist);
+    case (rlist)
+      4,5,6,7: begin
+        get_stack_adj_base = 12'd16;
+      end
+      8,9,10,11: begin
+        get_stack_adj_base = 12'd32;
+      end
+      12,13,14: begin
+        get_stack_adj_base = 12'd48;
+      end
+      15: begin
+        get_stack_adj_base = 12'd64;
+      end
+      default: begin
+        get_stack_adj_base = 12'd0;
+      end
+    endcase
+
+  endfunction
+
+  function automatic pushpop_rlist_e pushpop_reg_length(logic [3:0] rlist4);
+    case (rlist4)
+      'd0:     pushpop_reg_length = R_NONE;
+      'd1:     pushpop_reg_length = R_NONE;
+      'd2:     pushpop_reg_length = R_NONE;
+      'd3:     pushpop_reg_length = R_NONE;
+      'd4:     pushpop_reg_length = R_NONE;
+      'd5:     pushpop_reg_length = RA_S0;
+      'd6:     pushpop_reg_length = RA_S0_S1;
+      'd7:     pushpop_reg_length = RA_S0_S2;
+      'd8:     pushpop_reg_length = RA_S0_S3;
+      'd9:     pushpop_reg_length = RA_S0_S4;
+      'd10:    pushpop_reg_length = RA_S0_S5;
+      'd11:    pushpop_reg_length = RA_S0_S6;
+      'd12:    pushpop_reg_length = RA_S0_S7;
+      'd13:    pushpop_reg_length = RA_S0_S8;
+      'd14:    pushpop_reg_length = RA_S0_S9;
+      'd15:    pushpop_reg_length = RA_S0_S11;
+      default: pushpop_reg_length = R_NONE;
+    endcase
+  endfunction
+
+  // State machine definition
+  typedef enum logic [3:0] { S_IDLE, S_PUSH, S_POP, S_DMOVE, S_RA, S_SP, S_A0, S_RET} seq_state_e;
+
 endpackage

--- a/sva/cv32e40s_sequencer_sva.sv
+++ b/sva/cv32e40s_sequencer_sva.sv
@@ -1,0 +1,124 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// Authors:        Oystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Description:    RTL assertions for the sequencer module                    //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40x_sequencer_sva
+  import uvm_pkg::*;
+  import cv32e40x_pkg::*;
+(
+  input  logic           clk,
+  input  logic           rst_n,
+
+  input  logic           valid_i,
+  input  seq_t           instr_cnt_q,
+  input  seq_state_e     seq_state_q,
+  input  logic           seq_last_o,
+  input  seq_instr_e     seq_instr
+);
+
+  // After kill (or halt) or any cycle with !valid_i, all state must be reset.
+  a_kill_state:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    !valid_i |=> ((instr_cnt_q == '0) && (seq_state_q == S_IDLE)))
+      else `uvm_error("sequencer", "Sequencer state not reset after !valid_i.")
+
+  // todo: add assertion to check that atomic part cannot be killed
+
+
+  // Check max sequence length
+  // POPRETZ with rlist ra, s0-s11
+  // 13 register loads
+  // 1 stack pointer update
+  // 1 clearing of a0
+  // 1 return
+  // Total sequence length = 16 -> must signal seq_last_o on counter value 'd15
+  a_max_seq_len_popretz:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  valid_i && (seq_instr == POPRETZ) && (instr_cnt_q == 'd15)
+                  |->
+                  seq_last_o)
+      else `uvm_error("sequencer", "popretz sequence too long")
+
+  // Check max sequence length
+  // POPRET with rlist ra, s0-s11
+  // 13 register loads
+  // 1 stack pointer update
+  // 1 return
+  // Total sequence length = 15
+  a_max_seq_len_popret:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    valid_i && (seq_instr == POPRET)
+                    |->
+                    (instr_cnt_q < 'd15))
+        else `uvm_error("sequencer", "popret sequence too long")
+
+
+  // Check max sequence length
+  // POP with rlist ra, s0-s11
+  // 13 register loads
+  // 1 stack pointer update
+  // Total sequence length = 14
+  a_max_seq_len_pop:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    valid_i && (seq_instr == POP)
+                    |->
+                    (instr_cnt_q < 'd14))
+        else `uvm_error("sequencer", "pop sequence too long")
+
+  // Check max sequence length
+  // PUSH with rlist ra, s0-s11
+  // 13 register stores
+  // 1 stack pointer update
+  // Total sequence length = 14
+  a_max_seq_len_push:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    valid_i && (seq_instr == PUSH)
+                    |->
+                    (instr_cnt_q < 'd14))
+        else `uvm_error("sequencer", "push sequence too long")
+
+  // Check max sequence length
+  // MVA01S
+  // 2 register moves
+  a_max_seq_len_mva01s:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  valid_i && (seq_instr == MVA01S)
+                  |->
+                  (instr_cnt_q < 'd2))
+      else `uvm_error("sequencer", "mva01s sequence too long")
+
+  // Check max sequence length
+  // MVSA01
+  // 2 register moves
+  a_max_seq_len_mvsa01:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    valid_i && (seq_instr == MVSA01)
+                    |->
+                    (instr_cnt_q < 'd2))
+        else `uvm_error("sequencer", "mva01s sequence too long")
+endmodule
+

--- a/sva/cv32e40s_sequencer_sva.sv
+++ b/sva/cv32e40s_sequencer_sva.sv
@@ -26,9 +26,9 @@
 //                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-module cv32e40x_sequencer_sva
+module cv32e40s_sequencer_sva
   import uvm_pkg::*;
-  import cv32e40x_pkg::*;
+  import cv32e40s_pkg::*;
 (
   input  logic           clk,
   input  logic           rst_n,


### PR DESCRIPTION
Includes the new Zc sequencer.

SEC clean when ZC_EXT=1.

There are known failing assertions when ZC_EXT=1. These will be fixed once the sequencer is fully operational and merged in from CV32E40X.