### PR TITLE
Instruction side integrity check

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -38,6 +38,7 @@
   `include "cv32e40s_param_sva.sv"
   `include "cv32e40s_sequencer_sva.sv"
   `include "cv32e40s_clic_int_controller_sva.sv"
+  `include "cv32e40s_instr_obi_interface_sva.sv"
 `endif
 
 `include "cv32e40s_wrapper.vh"
@@ -424,6 +425,13 @@ endgenerate
       cv32e40s_sequencer_sva
         sequencer_sva (.*);
 */
+
+  bind cv32e40s_instr_obi_interface :
+    core_i.if_stage_i.instruction_obi_i
+    cv32e40s_instr_obi_interface_sva
+      instr_obi_sva( .m_c_obi_instr_if (core_i.m_c_obi_instr_if), // SVA monitor modport cannot connect to a master modport
+                     .*);
+
 `ifndef FORMAL
   bind cv32e40s_rvfi:
     rvfi_i

--- a/cv32e40s_manifest.flist
+++ b/cv32e40s_manifest.flist
@@ -76,6 +76,7 @@ ${DESIGN_RTL_DIR}/cv32e40s_pma.sv
 ${DESIGN_RTL_DIR}/cv32e40s_pmp.sv
 ${DESIGN_RTL_DIR}/cv32e40s_pc_target.sv
 ${DESIGN_RTL_DIR}/cv32e40s_pc_check.sv
+${DESIGN_RTL_DIR}/cv32e40s_rchk_check.sv
 ${DESIGN_RTL_DIR}/cv32e40s_lfsr.sv
 
 ${DESIGN_RTL_DIR}/../bhv/cv32e40s_sim_sffr.sv

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -63,7 +63,8 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   output privlvl_t                   instr_priv_lvl_o,
   output logic                       instr_is_clic_ptr_o,
   output logic                       instr_is_tbljmp_ptr_o,
-  output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o
+  output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o,
+  output logic                       integrity_err_o
 );
 
   // Counter for number of instructions in the FIFO
@@ -345,13 +346,15 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
     end
   end
 
+  // Set integrity error output
+  assign integrity_err_o = parity_err || rchk_err_0 || rchk_err_1;
 
   // Output instructions to the if stage
   always_comb
   begin
     instr_instr_o.bus_resp.rdata      = instr;
     instr_instr_o.bus_resp.err        = bus_err;
-    instr_instr_o.bus_resp.parity_err = xsecure_ctrl_i.cpuctrl.integrity ? parity_err : 1'b0;
+    instr_instr_o.bus_resp.parity_err = parity_err;
     instr_instr_o.mpu_status          = mpu_status;
     instr_instr_o.bus_resp.rchk       = '0;          // Tie off rchk here. Rchk is checked locally only the error bit is propagated.
     instr_instr_o.bus_resp.rchk_err   = rchk_err_0 || rchk_err_1;

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -210,9 +210,9 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   )
   rchk_0_i
   (
-    .resp_i (resp_q[rptr].bus_resp),
-    .enable (rchk_enable),
-    .err    (rchk_err_q0)
+    .resp_i   (resp_q[rptr].bus_resp),
+    .enable_i (rchk_enable),
+    .err_o    (rchk_err_q0)
   );
 
   // Rchk for buffer entry q1
@@ -222,9 +222,9 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   )
   rchk_1_i
   (
-    .resp_i (resp_q[rptr2].bus_resp),
-    .enable (rchk_enable),
-    .err    (rchk_err_q1)
+    .resp_i   (resp_q[rptr2].bus_resp),
+    .enable_i (rchk_enable),
+    .err_o    (rchk_err_q1)
   );
 
 

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -199,7 +199,8 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   /////////////////
   // RCHK
   /////////////////
-  // Enable any rchk checking when enabled in cpuctrl and response comes from a region with the integrity bit set in the PMA.
+  // Enable any rchk checking when enabled in cpuctrl
+  // PMA integrity bit is parth of bus_resp and will be checked within the rchk module.
   assign rchk_enable = xsecure_ctrl_i.cpuctrl.integrity;
 
   // Rchk for buffer entry q0
@@ -307,7 +308,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   end
 
   // Set integrity error output
-  assign integrity_err_o = parity_err || rchk_err_q0 || rchk_err_q1;
+  assign integrity_err_o = parity_err  || parity_err_unaligend || rchk_err_q0 || rchk_err_q1;
 
   // Output instructions to the if stage
   always_comb

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -39,6 +39,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   // Branch control
   input  logic [31:0]    branch_addr_i,
   output logic           prefetch_busy_o,
+  input xsecure_ctrl_t   xsecure_ctrl_i,
   output logic           one_txn_pend_n,
 
   // Interface to prefetcher
@@ -254,7 +255,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   begin
     instr_instr_o.bus_resp.rdata      = instr;
     instr_instr_o.bus_resp.err        = bus_err;
-    instr_instr_o.bus_resp.parity_err = parity_err;
+    instr_instr_o.bus_resp.parity_err = xsecure_ctrl_i.cpuctrl.integrity ? parity_err : 1'b0;
     instr_instr_o.mpu_status          = mpu_status;
     instr_instr_o.bus_resp.rchk       = '0;          // Tie off rchk here. Rchk is checked locally only an error bit is propagated.
     instr_valid_o = 1'b0;
@@ -266,7 +267,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
       // unaligned instruction
       instr_instr_o.bus_resp.rdata        = instr_unaligned;
       instr_instr_o.bus_resp.err          = bus_err_unaligned;
-      instr_instr_o.bus_resp.parity_err   = parity_err_unaligned;
+      instr_instr_o.bus_resp.parity_err   = xsecure_ctrl_i.cpuctrl.integrity ? parity_err_unaligned : 1'b0;
       instr_instr_o.mpu_status            = mpu_status_unaligned;
       // No instruction valid
       if (!valid) begin

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -308,7 +308,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   end
 
   // Set integrity error output
-  assign integrity_err_o = parity_err  || parity_err_unaligend || rchk_err_q0 || rchk_err_q1;
+  assign integrity_err_o = parity_err  || parity_err_unaligned || rchk_err_q0 || rchk_err_q1;
 
   // Output instructions to the if stage
   always_comb

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -164,12 +164,37 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
   logic                     aligned_is_compressed, unaligned_is_compressed;
 
+
+  // Rchk releated signals
+  logic       rchk_enable;             // "Global" rchk enable from cpuctrl
+  inst_resp_t rchk_0;                  // input to rchk computation
+  inst_resp_t rchk_1;                  // input to rchk computation
+  logic       rchk_en_misaligned_0;    // Enable rchk_0
+  logic       rchk_en_misaligned_1;    // Enable rchk_1
+  logic       rchk_en_aligned_0;
+  logic       rchk_en_aligned_1;
+  logic       rchk_sel_unaligned_0;    // Mux selector for rchk_0
+  logic       rchk_sel_unaligned_1;    // Mux selector for rchk_1
+  logic       rchk_sel_aligned_0;
+  logic       rchk_sel_aligned_1;
+  logic       rchk_sel_0;              // Mux selector for rchk_0
+  logic       rchk_sel_1;              // Mux selector for rchk_1
+  logic       rchk_err_0;
+  logic       rchk_err_1;
+
   // Aligned instructions will either be fully in index 0 or incoming data
   // This also applies for the bus_error and mpu_status
   assign instr      = (valid_q[rptr]) ? resp_q[rptr].bus_resp.rdata        : resp_i.bus_resp.rdata;
   assign bus_err    = (valid_q[rptr]) ? resp_q[rptr].bus_resp.err          : resp_i.bus_resp.err;
   assign parity_err = (valid_q[rptr]) ? resp_q[rptr].bus_resp.parity_err   : resp_i.bus_resp.parity_err;
   assign mpu_status = (valid_q[rptr]) ? resp_q[rptr].mpu_status            : resp_i.mpu_status;
+
+  // Set rchk mux selectors for aligned instructions
+  assign rchk_sel_aligned_0 = (valid_q[rptr]) ? 1'b1 : 1'b0;
+  assign rchk_sel_aligned_1 = 1'b0; // unused for aligned instructions
+  assign rchk_en_aligned_0 = 1'b1;
+  assign rchk_en_aligned_1 = 1'b0; // Never used for aligned instructions
+
 
   // Unaligned instructions will either be split across index 0 and 1, or index 0 and incoming data
   assign instr_unaligned = (valid_q[rptr2]) ? {resp_q[rptr2].bus_resp.rdata[15:0], instr[31:16]} : {resp_i.bus_resp.rdata[15:0], instr[31:16]};
@@ -185,12 +210,60 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   assign unaligned_is_compressed = instr[17:16] != 2'b11;
   assign aligned_is_compressed   = instr[1:0] != 2'b11;
 
+  /////////////////
+  // RCHK
+  /////////////////
+  // Enable any rchk checking when enabled in cpuctrl and response comes from a region with the integrity bit set in the PMA.
+  assign rchk_enable = xsecure_ctrl_i.cpuctrl.integrity;
+
+  // Rchk for resp_i or buffer entry q0
+  cv32e40s_rchk_check
+  #(
+      .RESP_TYPE (obi_inst_resp_t)
+  )
+  rchk_0_i
+  (
+    .resp_i (rchk_0.bus_resp),
+    .enable (rchk_en_0),
+    .err    (rchk_err_0)
+  );
+
+  // Rchk for buffer entry q0 or q1
+  cv32e40s_rchk_check
+  #(
+      .RESP_TYPE (obi_inst_resp_t)
+  )
+  rchk_1_i
+  (
+    .resp_i (rchk_1.bus_resp),
+    .enable (rchk_en_1),
+    .err    (rchk_err_1)
+  );
+
+  // Mux for which response to use in rchk checkers
+  assign rchk_sel_0 = instr_addr_o[1] ? rchk_sel_unaligned_0 : rchk_sel_aligned_0;
+  assign rchk_sel_1 = instr_addr_o[1] ? rchk_sel_unaligned_1 : rchk_sel_aligned_1;
+
+  // Mux for setting rchk checker enables
+  assign rchk_en_0 = instr_addr_o[1] ? (rchk_en_misaligned_0 && rchk_enable) : (rchk_en_aligned_0 && rchk_enable);
+  assign rchk_en_1 = instr_addr_o[1] ? (rchk_en_misaligned_1 && rchk_enable) : (rchk_en_aligned_1 && rchk_enable);
+
+  // Rchk_0 uses either entry q0 or incoming resp_i
+  assign rchk_0 = rchk_sel_0 ? resp_q[rptr] : resp_i;
+
+  // Rchk_1 uses either entry q0 or entry q1
+  assign rchk_1 = rchk_sel_1 ? resp_q[rptr2] : resp_q[rptr];
+
 
   // Set mpu_status and bus error for unaligned instructions
   always_comb begin
     mpu_status_unaligned = MPU_OK;
     bus_err_unaligned = 1'b0;
     parity_err_unaligned = 1'b0;
+    rchk_sel_unaligned_0 = 1'b0;
+    rchk_sel_unaligned_1 = 1'b0;
+    rchk_en_misaligned_0  = 1'b0;
+    rchk_en_misaligned_1  = 1'b0;
     // There is valid data in q1 (valid q0 is implied)
     if(valid_q[rptr2]) begin
       // Not compressed, need two sources
@@ -205,6 +278,12 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
         // Parity error from either entry
         parity_err_unaligned = (resp_q[rptr2].bus_resp.parity_err || resp_q[rptr].bus_resp.parity_err);
+
+        // Enable both rchks
+        rchk_en_misaligned_0 = 1'b1;
+        rchk_en_misaligned_1 = 1'b1;
+        rchk_sel_unaligned_0 = 1'b1; // q0
+        rchk_sel_unaligned_1 = 1'b0; // q1
       end else begin
         // Compressed, use only mpu_status from q0
         mpu_status_unaligned = resp_q[rptr].mpu_status;
@@ -214,6 +293,10 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
         // parity error from q0
         parity_err_unaligned    = resp_q[rptr].bus_resp.parity_err;
+
+        // Only one rchk needed
+        rchk_en_misaligned_0 = 1'b1;
+        rchk_sel_unaligned_0 = 1'b1; // q0
       end
     end else begin
       // There is no data in q1, check q0
@@ -230,6 +313,12 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
           // Parity error from q0 and resp_i
           parity_err_unaligned = (resp_q[rptr].bus_resp.parity_err || resp_i.bus_resp.parity_err);
+
+          // Two rchks needed
+          rchk_en_misaligned_0 = 1'b1;
+          rchk_en_misaligned_1 = 1'b1;
+          rchk_sel_unaligned_0 = 1'b0; // resp_i
+          rchk_sel_unaligned_1 = 1'b0; // q0
         end else begin
           // There is unaligned data in q0 and it is compressed
           mpu_status_unaligned = resp_q[rptr].mpu_status;
@@ -239,12 +328,19 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
           // Parity error from q0
           parity_err_unaligned = resp_q[rptr].bus_resp.parity_err;
+
+          // Only one rchk needed
+          rchk_en_misaligned_0 = 1'b1;
+          rchk_sel_unaligned_0 = 1'b1; // q0
         end
       end else begin
         // There is no data in the buffer, use input
         mpu_status_unaligned = resp_i.mpu_status;
         bus_err_unaligned    = resp_i.bus_resp.err;
         parity_err_unaligned    = resp_i.bus_resp.parity_err;
+
+        rchk_en_misaligned_0 = 1'b1;
+        rchk_sel_unaligned_0 = 1'b0; // resp_i
       end
     end
   end
@@ -257,7 +353,9 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
     instr_instr_o.bus_resp.err        = bus_err;
     instr_instr_o.bus_resp.parity_err = xsecure_ctrl_i.cpuctrl.integrity ? parity_err : 1'b0;
     instr_instr_o.mpu_status          = mpu_status;
-    instr_instr_o.bus_resp.rchk       = '0;          // Tie off rchk here. Rchk is checked locally only an error bit is propagated.
+    instr_instr_o.bus_resp.rchk       = '0;          // Tie off rchk here. Rchk is checked locally only the error bit is propagated.
+    instr_instr_o.bus_resp.rchk_err   = rchk_err_0 || rchk_err_1;
+    instr_instr_o.bus_resp.integrity  = 1'b0;        // Tie off integrity here, not used after this stage.
     instr_valid_o = 1'b0;
 
     // Invalidate output if we get killed

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -220,7 +220,7 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
     // Also deassert for trigger match, as with dcsr.timing==0 we do not execute before entering debug mode
     // CLIC pointer fetches go through the pipeline, but no write enables should be active.
     if (if_id_pipe_i.instr.bus_resp.err || !(if_id_pipe_i.instr.mpu_status == MPU_OK) || if_id_pipe_i.trigger_match ||
-        if_id_pipe_i.instr_meta.clic_ptr) begin
+        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr.bus_resp.parity_err || if_id_pipe_i.instr.bus_resp.rchk_err) begin
       ctrl_byp_o.deassert_we = 1'b1;
     end
 

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -305,6 +305,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        pc_err_if;
   logic        csr_err;
   logic        itf_int_err;
+  logic        integrity_err_if;
 
   // Minor Alert Triggers
   logic        lfsr_lockup;
@@ -473,7 +474,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   //                                 //
   /////////////////////////////////////
 
-  assign itf_int_err     = 1'b0; // todo: connect when interface integrity implemented
+  assign itf_int_err     = integrity_err_if; // todo:  || integrity_err_lsu
 
   cv32e40s_alert
     alert_i
@@ -577,6 +578,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
     // Dummy Instruction control
     .xsecure_ctrl_i      ( xsecure_ctrl             ),
     .lfsr_shift_o        ( lfsr_shift_if            ),
+
+    .integrity_err_o     ( integrity_err_if         ),
 
     // eXtension interface
     .xif_compressed_if   ( xif.cpu_compressed       ),

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -396,6 +396,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   assign m_c_obi_instr_if.resp_payload.rdata = instr_rdata_i;
   assign m_c_obi_instr_if.resp_payload.err   = instr_err_i;
   assign m_c_obi_instr_if.resp_payload.rchk  = instr_rchk_i;
+  assign m_c_obi_instr_if.resp_payload.parity_err = 1'b0; // Tie off here, will we populated in instr_obi_insterface.
 
   assign data_req_o                          = m_c_obi_data_if.s_req.req;
   assign data_reqpar_o                       = m_c_obi_data_if.s_req.reqpar;

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -1986,7 +1986,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .WIDTH      (32),
         .MASK       (CSR_CPUCTRL_MASK),
         .SHADOWCOPY (SECURE),
-        .RESETVALUE (32'd0)
+        .RESETVALUE (CPUCTRL_RESET_VAL)
       )
       cpuctrl_csr_i
       (
@@ -2457,7 +2457,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   assign menvcfg_rdata      = 32'h0;
   assign menvcfgh_rdata     = 32'h0;
 
-  assign cpuctrl_rdata      = 32'h0;
+  assign cpuctrl_rdata      = cpuctrl_q;
   assign secureseed0_rdata  = 32'h0;
   assign secureseed1_rdata  = 32'h0;
   assign secureseed2_rdata  = 32'h0;

--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -77,18 +77,18 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
 
     // Integrity // todo: ensure this will not get optimized away
     m_c_obi_data_if.req_payload.achk = {
-                                        ~^{m_c_obi_data_if.req_payload.wdata[31:24]},
-                                        ~^{m_c_obi_data_if.req_payload.wdata[23:16]},
-                                        ~^{m_c_obi_data_if.req_payload.wdata[15:8]},
-                                        ~^{m_c_obi_data_if.req_payload.wdata[7:0]},
-                                        ~^{6'b0},                                         // atop[5:0] = 6'b0
+                                        ^{m_c_obi_data_if.req_payload.wdata[31:24]},
+                                        ^{m_c_obi_data_if.req_payload.wdata[23:16]},
+                                        ^{m_c_obi_data_if.req_payload.wdata[15:8]},
+                                        ^{m_c_obi_data_if.req_payload.wdata[7:0]},
+                                        ^{6'b0},                                         // atop[5:0] = 6'b0
                                         ~^{m_c_obi_data_if.req_payload.dbg},
                                         ~^{m_c_obi_data_if.req_payload.be[3:0], m_c_obi_data_if.req_payload.we},
                                         ~^{m_c_obi_data_if.req_payload.prot[2:0], m_c_obi_data_if.req_payload.memtype[1:0]},
-                                        ~^{m_c_obi_data_if.req_payload.addr[31:24]},
-                                        ~^{m_c_obi_data_if.req_payload.addr[23:16]},
-                                        ~^{m_c_obi_data_if.req_payload.addr[15:8]},
-                                        ~^{m_c_obi_data_if.req_payload.addr[7:0]}
+                                        ^{m_c_obi_data_if.req_payload.addr[31:24]},
+                                        ^{m_c_obi_data_if.req_payload.addr[23:16]},
+                                        ^{m_c_obi_data_if.req_payload.addr[15:8]},
+                                        ^{m_c_obi_data_if.req_payload.addr[7:0]}
                                         };
 
   end

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -136,8 +136,10 @@ module cv32e40s_dummy_instr
   assign instr[11: 7] = (opcode == OPCODE_BRANCH) ? {imm[4:1], imm[11]}  : rd;
   assign instr[ 6: 0] = opcode;
 
-  assign dummy_instr_o.bus_resp.rdata = instr;
-  assign dummy_instr_o.bus_resp.err   = 1'b0;
-  assign dummy_instr_o.mpu_status     = MPU_OK;
+  assign dummy_instr_o.bus_resp.rdata      = instr;
+  assign dummy_instr_o.bus_resp.err        = 1'b0;
+  assign dummy_instr_o.mpu_status          = MPU_OK;
+  assign dummy_instr_o.bus_resp.parity_err = 1'b0;
+  assign dummy_instr_o.bus_resp.rchk_err   = 1'b0;
 
 endmodule : cv32e40s_dummy_instr

--- a/rtl/cv32e40s_ex_stage.sv
+++ b/rtl/cv32e40s_ex_stage.sv
@@ -155,6 +155,8 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
   // Exception happened during IF or ID, or trigger match in ID (converted to NOP).
   // signal needed for ex_valid to go high in such cases
   assign previous_exception = (id_ex_pipe_i.illegal_insn                 ||
+                               id_ex_pipe_i.instr.bus_resp.parity_err    ||
+                               id_ex_pipe_i.instr.bus_resp.rchk_err      ||
                                id_ex_pipe_i.instr.bus_resp.err           ||
                                (id_ex_pipe_i.instr.mpu_status != MPU_OK) ||
                                id_ex_pipe_i.trigger_match)               &&

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -656,9 +656,11 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
         if (if_id_pipe_i.instr_meta.compressed) begin
           // Overwrite instruction word in case of compressed instruction
-          id_ex_pipe_o.instr.bus_resp.rdata <= {16'h0, if_id_pipe_i.compressed_instr};
-          id_ex_pipe_o.instr.bus_resp.err   <= if_id_pipe_i.instr.bus_resp.err;
-          id_ex_pipe_o.instr.mpu_status     <= if_id_pipe_i.instr.mpu_status;
+          id_ex_pipe_o.instr.bus_resp.rdata      <= {16'h0, if_id_pipe_i.compressed_instr};
+          id_ex_pipe_o.instr.bus_resp.err        <= if_id_pipe_i.instr.bus_resp.err;
+          id_ex_pipe_o.instr.bus_resp.parity_err <= if_id_pipe_i.instr.bus_resp.parity_err;
+          id_ex_pipe_o.instr.bus_resp.rchk_err   <= if_id_pipe_i.instr.bus_resp.rchk_err;
+          id_ex_pipe_o.instr.mpu_status          <= if_id_pipe_i.instr.mpu_status;
         end else begin
           id_ex_pipe_o.instr                <= if_id_pipe_i.instr;
         end

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -424,7 +424,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   // Set flag to indicate that instruction/sequence will be aborted due to known exceptions or trigger match
   assign abort_op_o = dummy_insert ? 1'b0 :
-                      (instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK) || trigger_match_i);
+                      (instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK) ||
+                      (instr_decompressed.bus_resp.parity_err) || (instr_decompressed.bus_resp.rchk_err) || trigger_match_i);
 
   assign prefetch_valid_o = prefetch_valid;
   // Populate instruction meta data
@@ -500,8 +501,10 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
           if_id_pipe_o.ptr                <= instr_decompressed.bus_resp.rdata;
 
           // Need to update bus error status and mpu status, but may omit the 32-bit instruction word
-          if_id_pipe_o.instr.bus_resp.err <= instr_decompressed.bus_resp.err;
-          if_id_pipe_o.instr.mpu_status   <= instr_decompressed.mpu_status;
+          if_id_pipe_o.instr.bus_resp.err        <= instr_decompressed.bus_resp.err;
+          if_id_pipe_o.instr.mpu_status          <= instr_decompressed.mpu_status;
+          if_id_pipe_o.instr.bus_resp.parity_err <= instr_decompressed.bus_resp.parity_err;
+          if_id_pipe_o.instr.bus_resp.rchk_err   <= instr_decompressed.bus_resp.rchk_err;
         end else begin
           // Regular instruction, update the whole instr field
           if_id_pipe_o.instr          <= dummy_insert ? dummy_instr :

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -304,6 +304,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
 
   cv32e40s_instr_obi_interface
+  #(
+    .MAX_OUTSTANDING (2) // todo: hook up to parameter
+  )
   instruction_obi_i
   (
     .clk                  ( clk              ),

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -327,7 +327,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .resp_valid_o         ( bus_resp_valid   ),
     .resp_o               ( bus_resp         ),
 
-    .integrity_err        ( integrity_err_obi),   // immediate integrity error, either parity or chk
+    .integrity_err_o      ( integrity_err_obi),   // immediate integrity error, either parity or chk
     .m_c_obi_instr_if     ( m_c_obi_instr_if )
   );
 

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -242,6 +242,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .resp_valid_i             ( prefetch_resp_valid         ),
     .resp_i                   ( prefetch_inst_resp          ),
 
+    .xsecure_ctrl_i           ( xsecure_ctrl_i              ),
+
     // Prefetch Buffer Status
     .prefetch_busy_o          ( prefetch_busy               ),
     .one_txn_pend_n           ( prefetch_one_txn_pend_n     ),

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -328,6 +328,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .resp_o               ( bus_resp         ),
 
     .integrity_err_o      ( integrity_err_obi),   // immediate integrity error, either parity or chk
+
+    .xsecure_ctrl_i       ( xsecure_ctrl_i   ),
     .m_c_obi_instr_if     ( m_c_obi_instr_if )
   );
 

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -167,18 +167,18 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
 
   always_comb begin
     achk = {
-      ~^{8'b0},                                         // wdata[31:24] = 8'b0
-      ~^{8'b0},                                         // wdata[23:16] = 8'b0
-      ~^{8'b0},                                         // wdata[15:8] = 8'b0
-      ~^{8'b0},                                         // wdata[7:0] = 8'b0
-      ~^{6'b0},                                         // atop[5:0] = 6'b0
+      ^{8'b0},                                         // wdata[31:24] = 8'b0
+      ^{8'b0},                                         // wdata[23:16] = 8'b0
+      ^{8'b0},                                         // wdata[15:8] = 8'b0
+      ^{8'b0},                                         // wdata[7:0] = 8'b0
+      ^{6'b0},                                         // atop[5:0] = 6'b0
       ~^{m_c_obi_instr_if.req_payload.dbg},
       ~^{4'b1111, 1'b0},                                // be[3:0] = 4'b1111, we = 1'b0
       ~^{m_c_obi_instr_if.req_payload.prot[2:0], m_c_obi_instr_if.req_payload.memtype[1:0]},
-      ~^{m_c_obi_instr_if.req_payload.addr[31:24]},
-      ~^{m_c_obi_instr_if.req_payload.addr[23:16]},
-      ~^{m_c_obi_instr_if.req_payload.addr[15:8]},
-      ~^{m_c_obi_instr_if.req_payload.addr[7:2], 2'b00} // Bits 1:0 are tied to zero in the core level.
+      ^{m_c_obi_instr_if.req_payload.addr[31:24]},
+      ^{m_c_obi_instr_if.req_payload.addr[23:16]},
+      ^{m_c_obi_instr_if.req_payload.addr[15:8]},
+      ^{m_c_obi_instr_if.req_payload.addr[7:2], 2'b00} // Bits 1:0 are tied to zero in the core level.
     };
   end
 

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -53,6 +53,8 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
 
   output logic           integrity_err_o,       // parity error or rchk error, fans into alert_major_o
 
+  input xsecure_ctrl_t   xsecure_ctrl_i,
+
   // OBI interface
   if_c_obi.master        m_c_obi_instr_if
 );
@@ -291,15 +293,15 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   end
 
 
-  // Enable rchk when in response phase
-  assign rchk_en = m_c_obi_instr_if.s_rvalid.rvalid;
+  // Enable rchk when in response phase and cpuctrl.integrity is set
+  assign rchk_en = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity;
   cv32e40s_rchk_check
   #(
       .RESP_TYPE (obi_inst_resp_t)
   )
   rchk_i
   (
-    .resp_i (resp_o),  // Using local output, as is has the integrity bit appended from the fifo. Otherwise inputs from bus.
+    .resp_i (resp_o),  // Using local output, as is has the PMA integrity bit appended from the fifo. Otherwise inputs from bus.
     .enable (rchk_en),
     .err    (rchk_err)
   );

--- a/rtl/cv32e40s_prefetch_unit.sv
+++ b/rtl/cv32e40s_prefetch_unit.sv
@@ -60,6 +60,9 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
   output logic                       one_txn_pend_n,
   output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o,
 
+  // Xsecure control (for parity and rchk)
+  input xsecure_ctrl_t  xsecure_ctrl_i,
+
   // Prefetch Buffer Status
   output logic        prefetch_busy_o
 );
@@ -115,6 +118,8 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
 
     .branch_addr_i         ( branch_addr_i           ),
     .prefetch_busy_o       ( prefetch_busy_o         ),
+
+    .xsecure_ctrl_i        ( xsecure_ctrl_i          ),
 
     // prefetch unit
     .fetch_valid_o         ( fetch_valid             ),

--- a/rtl/cv32e40s_prefetch_unit.sv
+++ b/rtl/cv32e40s_prefetch_unit.sv
@@ -48,6 +48,7 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
   output privlvl_t    prefetch_priv_lvl_o,
   output logic        prefetch_is_clic_ptr_o,
   output logic        prefetch_is_tbljmp_ptr_o,
+  output logic        prefetch_integrity_err_o,
 
   // Transaction interface to obi interface
   output logic        trans_valid_o,
@@ -141,7 +142,8 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
     .instr_addr_o          ( prefetch_addr_o         ),
     .instr_priv_lvl_o      ( prefetch_priv_lvl_o     ),
     .instr_is_clic_ptr_o   ( prefetch_is_clic_ptr_o  ),
-    .instr_is_tbljmp_ptr_o ( prefetch_is_tbljmp_ptr_o)
+    .instr_is_tbljmp_ptr_o ( prefetch_is_tbljmp_ptr_o),
+    .integrity_err_o       ( prefetch_integrity_err_o)
 
   );
 

--- a/rtl/cv32e40s_rchk_check.sv
+++ b/rtl/cv32e40s_rchk_check.sv
@@ -36,8 +36,8 @@ module cv32e40s_rchk_check import cv32e40s_pkg::*;
 )
 (
   input  RESP_TYPE resp_i,
-  input  logic     enable,
-  output logic     err
+  input  logic     enable_i,
+  output logic     err_o
 );
 
 logic [4:0] rchk_res;
@@ -53,6 +53,6 @@ always_comb begin
   };
 end
 
-assign err = (enable && resp_i.integrity)? (rchk_res != resp_i.rchk) : 1'b0;
+assign err_o = (enable_i && resp_i.integrity)? (rchk_res != resp_i.rchk) : 1'b0;
 
 endmodule

--- a/rtl/cv32e40s_rchk_check.sv
+++ b/rtl/cv32e40s_rchk_check.sv
@@ -1,0 +1,58 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License").
+//
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+//
+// You may obtain a copy of the License at:
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+// Engineer:       Øystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Design Name:    cv32e40s_rchk_check                                        //
+// Project Name:   CV32E40S                                                   //
+// Language:       SystemVerilog                                              //
+//                                                                            //
+// Description:    This module will check the recomputed rchk values          //
+//                 and signal an error if enalbed and checksums does not match//
+////////////////////////////////////////////////////////////////////////////////
+
+
+module cv32e40s_rchk_check import cv32e40s_pkg::*;
+#(
+  parameter type RESP_TYPE = obi_inst_resp_t
+)
+(
+  input  RESP_TYPE resp_i,
+  input  logic     enable,
+  output logic     err
+);
+
+logic [4:0] rchk_res;
+
+// Compute rchk from response inputs
+always_comb begin
+  rchk_res = {
+    ^{resp_i.err, 1'b0},
+    ^{resp_i.rdata[31:24]},
+    ^{resp_i.rdata[23:16]},
+    ^{resp_i.rdata[15:8]},
+    ^{resp_i.rdata[7:0]}
+  };
+end
+
+assign err = (enable && resp_i.integrity)? (rchk_res != resp_i.rchk) : 1'b0;
+
+endmodule

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -479,7 +479,7 @@ parameter CSR_MINTSTATUS_MASK   = 32'hFF000000;
 parameter CSR_MINTTHRESH_MASK   = 32'h000000FF;
 parameter CSR_MCLICBASE_MASK    = 32'hFFFFF000;
 parameter CSR_MSCRATCH_MASK     = 32'hFFFFFFFF;
-parameter CSR_CPUCTRL_MASK      = 32'h000F0007; // todo: will need to become 32'h000F000F
+parameter CSR_CPUCTRL_MASK      = 32'h000F001F;
 parameter CSR_PMPNCFG_MASK      = 8'hFF;
 parameter CSR_PMPADDR_MASK      = 32'hFFFFFFFF;
 parameter CSR_MSECCFG_MASK      = 32'h00000007;
@@ -509,7 +509,9 @@ parameter int unsigned CSR_MFIX_BIT_HIGH = 31;
 typedef struct packed {
   logic [31:20] zero1;
   logic [19:16] rnddummyfreq;
-  logic [15: 3] zero0;
+  logic [15: 5] zero0;
+  logic         integrity;
+  logic         pc_hardening;
   logic         rndhint;
   logic         rnddummy;
   logic         dataindtiming;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -517,6 +517,13 @@ typedef struct packed {
   logic         dataindtiming;
 } cpuctrl_t;
 
+parameter cpuctrl_t CPUCTRL_RESET_VAL = '{
+  integrity     : 1'b1,
+  pc_hardening  : 1'b1,
+  dataindtiming : 1'b1,
+  default:    '0};
+
+
 typedef struct packed {
   logic [31:0] lfsr2;
   logic [31:0] lfsr1;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -938,14 +938,15 @@ typedef enum logic[3:0] {
 } pc_mux_e;
 
 // Exception Cause
-parameter EXC_CAUSE_INSTR_FAULT     = 11'h01;
-parameter EXC_CAUSE_ILLEGAL_INSN    = 11'h02;
-parameter EXC_CAUSE_BREAKPOINT      = 11'h03;
-parameter EXC_CAUSE_LOAD_FAULT      = 11'h05;
-parameter EXC_CAUSE_STORE_FAULT     = 11'h07;
-parameter EXC_CAUSE_ECALL_UMODE     = 11'h08;
-parameter EXC_CAUSE_ECALL_MMODE     = 11'h0B;
-parameter EXC_CAUSE_INSTR_BUS_FAULT = 11'h30;
+parameter EXC_CAUSE_INSTR_FAULT           = 11'h01;
+parameter EXC_CAUSE_ILLEGAL_INSN          = 11'h02;
+parameter EXC_CAUSE_BREAKPOINT            = 11'h03;
+parameter EXC_CAUSE_LOAD_FAULT            = 11'h05;
+parameter EXC_CAUSE_STORE_FAULT           = 11'h07;
+parameter EXC_CAUSE_ECALL_UMODE           = 11'h08;
+parameter EXC_CAUSE_ECALL_MMODE           = 11'h0B;
+parameter EXC_CAUSE_INSTR_INTEGRITY_FAULT = 11'h19;
+parameter EXC_CAUSE_INSTR_BUS_FAULT       = 11'h30;
 
 parameter INT_CAUSE_LSU_LOAD_FAULT  = 11'h400;
 parameter INT_CAUSE_LSU_STORE_FAULT = 11'h401;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1101,6 +1101,7 @@ typedef struct packed {
   logic [INSTR_DATA_WIDTH-1:0] rdata;
   logic                        err;
   logic [4:0]                  rchk;
+  logic                        parity_err;
 } obi_inst_resp_t;
 
 typedef struct packed {
@@ -1131,7 +1132,7 @@ typedef struct packed {
 parameter inst_resp_t INST_RESP_RESET_VAL = '{
   // Setting rdata[1:0] to 2'b11 to easily assert that all
   // instructions in ID are uncompressed
-  bus_resp    : '{rdata: 32'h3, err: 1'b0, rchk: 5'b0},
+  bus_resp    : '{rdata: 32'h3, err: 1'b0, rchk: 5'b0, parity_err: 1'b0},
   mpu_status  : MPU_OK
 };
 

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1103,7 +1103,9 @@ typedef struct packed {
   logic [INSTR_DATA_WIDTH-1:0] rdata;
   logic                        err;
   logic [4:0]                  rchk;
+  logic                        rchk_err;
   logic                        parity_err;
+  logic                        integrity;
 } obi_inst_resp_t;
 
 typedef struct packed {
@@ -1134,7 +1136,7 @@ typedef struct packed {
 parameter inst_resp_t INST_RESP_RESET_VAL = '{
   // Setting rdata[1:0] to 2'b11 to easily assert that all
   // instructions in ID are uncompressed
-  bus_resp    : '{rdata: 32'h3, err: 1'b0, rchk: 5'b0, parity_err: 1'b0},
+  bus_resp    : '{rdata: 32'h3, err: 1'b0, rchk: 5'b0, parity_err: 1'b0, rchk_err: 1'b0, integrity: 1'b0},
   mpu_status  : MPU_OK
 };
 

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -611,33 +611,33 @@ end
   logic [11:0] data_achk_expected;
 
   assign instr_achk_expected = {
-    ~^{8'b0},
-    ~^{8'b0},
-    ~^{8'b0},
-    ~^{8'b0},
-    ~^{6'b0},
+    ^{8'b0},
+    ^{8'b0},
+    ^{8'b0},
+    ^{8'b0},
+    ^{6'b0},
     ~^{instr_dbg_o},
     ~^{4'b1111, 1'b0},
     ~^{instr_prot_o[2:0], instr_memtype_o[1:0]},
-    ~^{instr_addr_o[31:24]},
-    ~^{instr_addr_o[23:16]},
-    ~^{instr_addr_o[15:8]},
-    ~^{instr_addr_o[7:0]}
+    ^{instr_addr_o[31:24]},
+    ^{instr_addr_o[23:16]},
+    ^{instr_addr_o[15:8]},
+    ^{instr_addr_o[7:0]}
   };
 
   assign data_achk_expected = {
-    ~^{data_wdata_o[31:24]},
-    ~^{data_wdata_o[23:16]},
-    ~^{data_wdata_o[15:8]},
-    ~^{data_wdata_o[7:0]},
-    ~^{6'b0},
+    ^{data_wdata_o[31:24]},
+    ^{data_wdata_o[23:16]},
+    ^{data_wdata_o[15:8]},
+    ^{data_wdata_o[7:0]},
+    ^{6'b0},
     ~^{data_dbg_o},
     ~^{data_be_o[3:0], data_we_o},
     ~^{data_prot_o[2:0], data_memtype_o[1:0]},
-    ~^{data_addr_o[31:24]},
-    ~^{data_addr_o[23:16]},
-    ~^{data_addr_o[15:8]},
-    ~^{data_addr_o[7:0]}
+    ^{data_addr_o[31:24]},
+    ^{data_addr_o[23:16]},
+    ^{data_addr_o[15:8]},
+    ^{data_addr_o[7:0]}
   };
 
   a_no_checksum_err:

--- a/sva/cv32e40s_instr_obi_interface_sva.sv
+++ b/sva/cv32e40s_instr_obi_interface_sva.sv
@@ -33,10 +33,11 @@ module cv32e40s_instr_obi_interface_sva
   input logic           gntpar_err,
   input logic           gntpar_err_q,
   input obi_inst_resp_t resp_o,
+  input obi_inst_req_t  trans_i,
   input logic           gntpar_err_resp
 );
 
- // Support logic (FIFO) to track grant parity fault and integrity bit
+ // Support logic (FIFO) to track grant parity fault
 
 localparam MAX_OUTSTND_TXN = 5; // This needs to be larger (or equal) to the max outstanding transactions in IF and LSU
 
@@ -44,31 +45,31 @@ typedef enum logic [1:0] {GNT_ERR, GNT_NOERR, GNT_NONE} gnt_err_chck_e;
 logic exp_gnt_err;
 logic [$clog2(MAX_OUTSTND_TXN)-1:0] oldest_txn;
 
-gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] trans_fifo_q;
-gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] trans_fifo_n;
-gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] trans_fifo_tmp;
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] gnt_fifo_q;
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] gnt_fifo_n;
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] gnt_fifo_tmp;
 
 always_comb begin
-  trans_fifo_n   = trans_fifo_q;
-  trans_fifo_tmp = trans_fifo_q;
+  gnt_fifo_n   = gnt_fifo_q;
+  gnt_fifo_tmp = gnt_fifo_q;
 
   casez ({m_c_obi_instr_if.s_req.req, m_c_obi_instr_if.s_gnt.gnt, m_c_obi_instr_if.s_rvalid.rvalid})
       3'b110: begin
         // Accepted address phase, add one entry to FIFO
-        trans_fifo_n = (gntpar_err || gntpar_err_q) ?
-                               {trans_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
-                               {trans_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
+        gnt_fifo_n = (gntpar_err || gntpar_err_q) ?
+                               {gnt_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
+                               {gnt_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
       end
       3'b0?1, 3'b?01: begin
         // Response phase, remove oldest entry from FIFO
-        trans_fifo_n[oldest_txn] = GNT_NONE;
+        gnt_fifo_n[oldest_txn] = GNT_NONE;
       end
       3'b111: begin
         // Accepted address phase and response phase. Clear oldest transaction and add new to FIFO
-        trans_fifo_tmp[oldest_txn] = GNT_NONE;
-        trans_fifo_n = (gntpar_err || gntpar_err_q) ?
-                               {trans_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
-                               {trans_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
+        gnt_fifo_tmp[oldest_txn] = GNT_NONE;
+        gnt_fifo_n = (gntpar_err || gntpar_err_q) ?
+                               {gnt_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
+                               {gnt_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
       end
       default; // Do nothing
     endcase
@@ -77,10 +78,10 @@ end
 // FIFO
 always_ff @ (posedge clk, negedge rst_n) begin
   if (!rst_n) begin
-    trans_fifo_q <= {MAX_OUTSTND_TXN{GNT_NONE}};
+    gnt_fifo_q <= {MAX_OUTSTND_TXN{GNT_NONE}};
   end
   else begin
-    trans_fifo_q <= trans_fifo_n;
+    gnt_fifo_q <= gnt_fifo_n;
   end
 end
 
@@ -88,19 +89,82 @@ end
 always_comb begin
   oldest_txn = '0;
   for (int i = 0;  i < MAX_OUTSTND_TXN; i++) begin
-    if (trans_fifo_q[i] != GNT_NONE) begin
+    if (gnt_fifo_q[i] != GNT_NONE) begin
       oldest_txn = i;
     end
   end
 end
 
 // GNT error from the oldest transaction
-assign exp_gnt_err = (trans_fifo_q[oldest_txn] == GNT_ERR);
+assign exp_gnt_err = (gnt_fifo_q[oldest_txn] == GNT_ERR);
 
-// Assert that integrity bit from MPU corresponds to the expected value
-a_pma_integrity :
+// Assert that grant error bit comes out in order
+a_instr_obi_gnt_fifo :
   assert property (@(posedge clk) disable iff (!rst_n)
                    m_c_obi_instr_if.s_rvalid.rvalid |-> exp_gnt_err == gntpar_err_resp)
     else `uvm_error("mpu", "GNT error bit not correct")
 
+
+typedef enum logic [1:0] {INT, NOINT, INT_NONE} integrity_e;
+logic exp_int;
+logic [$clog2(MAX_OUTSTND_TXN)-1:0] oldest_txn_int;
+
+integrity_e [MAX_OUTSTND_TXN-1:0] int_fifo_q;
+integrity_e [MAX_OUTSTND_TXN-1:0] int_fifo_n;
+integrity_e [MAX_OUTSTND_TXN-1:0] int_fifo_tmp;
+
+always_comb begin
+  int_fifo_n   = int_fifo_q;
+  int_fifo_tmp = int_fifo_q;
+
+  casez ({m_c_obi_instr_if.s_req.req, m_c_obi_instr_if.s_gnt.gnt, m_c_obi_instr_if.s_rvalid.rvalid})
+      3'b110: begin
+        // Accepted address phase, add one entry to FIFO
+        int_fifo_n = trans_i.integrity ?
+                               {int_fifo_q[MAX_OUTSTND_TXN-2:0], INT} :
+                               {int_fifo_q[MAX_OUTSTND_TXN-2:0], NOINT};
+      end
+      3'b0?1, 3'b?01: begin
+        // Response phase, remove oldest entry from FIFO
+        int_fifo_n[oldest_txn] = INT_NONE;
+      end
+      3'b111: begin
+        // Accepted address phase and response phase. Clear oldest transaction and add new to FIFO
+        int_fifo_tmp[oldest_txn] = INT_NONE;
+        int_fifo_n = trans_i.integrity ?
+                               {int_fifo_tmp[MAX_OUTSTND_TXN-2:0], INT} :
+                               {int_fifo_tmp[MAX_OUTSTND_TXN-2:0], NOINT};
+      end
+      default; // Do nothing
+    endcase
+end
+
+// FIFO
+always_ff @ (posedge clk, negedge rst_n) begin
+  if (!rst_n) begin
+    int_fifo_q <= {MAX_OUTSTND_TXN{INT_NONE}};
+  end
+  else begin
+    int_fifo_q <= int_fifo_n;
+  end
+end
+
+// Locate oldest entry in FIFO
+always_comb begin
+  oldest_txn_int = '0;
+  for (int i = 0;  i < MAX_OUTSTND_TXN; i++) begin
+    if (int_fifo_q[i] != INT_NONE) begin
+      oldest_txn_int = i;
+    end
+  end
+end
+
+// GNT error from the oldest transaction
+assign exp_int = (int_fifo_q[oldest_txn_int] == INT);
+
+// Assert that trans integrity bit comes out in order
+a_instr_obi_int_fifo :
+  assert property (@(posedge clk) disable iff (!rst_n)
+                   m_c_obi_instr_if.s_rvalid.rvalid |-> exp_int == resp_o.integrity)
+    else `uvm_error("mpu", "Integrity bit not correct")
 endmodule

--- a/sva/cv32e40s_instr_obi_interface_sva.sv
+++ b/sva/cv32e40s_instr_obi_interface_sva.sv
@@ -1,0 +1,106 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License");
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// Authors:        Oystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Description:    RTL assertions for the instr_obi_interface module          //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40s_instr_obi_interface_sva
+  import uvm_pkg::*;
+  import cv32e40s_pkg::*;
+(
+  input logic           clk,
+  input logic           rst_n,
+  if_c_obi.monitor      m_c_obi_instr_if,
+  input logic           gntpar_err,
+  input logic           gntpar_err_q,
+  input obi_inst_resp_t resp_o,
+  input logic           gntpar_err_resp
+);
+
+ // Support logic (FIFO) to track grant parity fault and integrity bit
+
+localparam MAX_OUTSTND_TXN = 5; // This needs to be larger (or equal) to the max outstanding transactions in IF and LSU
+
+typedef enum logic [1:0] {GNT_ERR, GNT_NOERR, GNT_NONE} gnt_err_chck_e;
+logic exp_gnt_err;
+logic [$clog2(MAX_OUTSTND_TXN)-1:0] oldest_txn;
+
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] trans_fifo_q;
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] trans_fifo_n;
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] trans_fifo_tmp;
+
+always_comb begin
+  trans_fifo_n   = trans_fifo_q;
+  trans_fifo_tmp = trans_fifo_q;
+
+  casez ({m_c_obi_instr_if.s_req.req, m_c_obi_instr_if.s_gnt.gnt, m_c_obi_instr_if.s_rvalid.rvalid})
+      3'b110: begin
+        // Accepted address phase, add one entry to FIFO
+        trans_fifo_n = (gntpar_err || gntpar_err_q) ?
+                               {trans_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
+                               {trans_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
+      end
+      3'b0?1, 3'b?01: begin
+        // Response phase, remove oldest entry from FIFO
+        trans_fifo_n[oldest_txn] = GNT_NONE;
+      end
+      3'b111: begin
+        // Accepted address phase and response phase. Clear oldest transaction and add new to FIFO
+        trans_fifo_tmp[oldest_txn] = GNT_NONE;
+        trans_fifo_n = (gntpar_err || gntpar_err_q) ?
+                               {trans_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
+                               {trans_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
+      end
+      default; // Do nothing
+    endcase
+end
+
+// FIFO
+always_ff @ (posedge clk, negedge rst_n) begin
+  if (!rst_n) begin
+    trans_fifo_q <= {MAX_OUTSTND_TXN{GNT_NONE}};
+  end
+  else begin
+    trans_fifo_q <= trans_fifo_n;
+  end
+end
+
+// Locate oldest entry in FIFO
+always_comb begin
+  oldest_txn = '0;
+  for (int i = 0;  i < MAX_OUTSTND_TXN; i++) begin
+    if (trans_fifo_q[i] != GNT_NONE) begin
+      oldest_txn = i;
+    end
+  end
+end
+
+// GNT error from the oldest transaction
+assign exp_gnt_err = (trans_fifo_q[oldest_txn] == GNT_ERR);
+
+// Assert that integrity bit from MPU corresponds to the expected value
+a_pma_integrity :
+  assert property (@(posedge clk) disable iff (!rst_n)
+                   m_c_obi_instr_if.s_rvalid.rvalid |-> exp_gnt_err == gntpar_err_resp)
+    else `uvm_error("mpu", "GNT error bit not correct")
+
+endmodule


### PR DESCRIPTION
Instruction OBI parity for gnt and rvalid checked in instruction OBI interface. If a parity fault occurs here, alert_major_o will go high when not in reset. 

Checking instr_rchk_i in the instruction OBI interface when rvalid=1, PMA.integrity=1 and the cpuctrl.integrity bit is set. Fans into alert_major_o. Alignment buffer checks two RCHK checksums, once for each buffer entry that may be used when assembling instructions  (plus the error bit from the obi interface rchk).

Any detected parity or rchk fault within the alignment buffer is a source for alert_major_o. In addition, such faults will travel with the instruction(s) affected and raise exceptions once in WB. 

Both instruction and LSU achk updated to match user manual 0.5.0.

PR includes turning on cpuctrl.integrity, cpuctrl.pc_hardening and cpuctrl.dataindtiming at reset in addition to addign proper RMW behavior for cpuctrl.
