### PR TITLE
Added LSU integrity checking.

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -39,6 +39,7 @@
   `include "cv32e40s_sequencer_sva.sv"
   `include "cv32e40s_clic_int_controller_sva.sv"
   `include "cv32e40s_instr_obi_interface_sva.sv"
+  `include "cv32e40s_data_obi_interface_sva.sv"
 `endif
 
 `include "cv32e40s_wrapper.vh"
@@ -431,6 +432,12 @@ endgenerate
     cv32e40s_instr_obi_interface_sva
       instr_obi_sva( .m_c_obi_instr_if (core_i.m_c_obi_instr_if), // SVA monitor modport cannot connect to a master modport
                      .*);
+
+  bind cv32e40s_data_obi_interface :
+    core_i.load_store_unit_i.data_obi_i
+    cv32e40s_data_obi_interface_sva
+      data_obi_sva( .m_c_obi_data_if (core_i.m_c_obi_data_if), // SVA monitor modport cannot connect to a master modport
+                    .*);
 
 `ifndef FORMAL
   bind cv32e40s_rvfi:

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -167,7 +167,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
 
   // Rchk releated signals
-  logic [1:0]  rchk_enable;             // "Global" rchk enable from cpuctrl
+  logic [1:0]  rchk_enable;             // "Global" rchk enable from cpuctrl. Bit0 for rdata, bit1 for bus error
   logic        rchk_err_q0;             // rchk error in entry q0
   logic        rchk_err_q1;             // rchk error in entry q1
   logic        rchk_err_aligned;        // rchk error for aligned instructions

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -167,11 +167,11 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
 
   // Rchk releated signals
-  logic       rchk_enable;             // "Global" rchk enable from cpuctrl
-  logic       rchk_err_q0;             // rchk error in entry q0
-  logic       rchk_err_q1;             // rchk error in entry q1
-  logic       rchk_err_aligned;        // rchk error for aligned instructions
-  logic       rchk_err_unaligned;      // rchk error for unaligned instructions
+  logic [1:0]  rchk_enable;             // "Global" rchk enable from cpuctrl
+  logic        rchk_err_q0;             // rchk error in entry q0
+  logic        rchk_err_q1;             // rchk error in entry q1
+  logic        rchk_err_aligned;        // rchk error for aligned instructions
+  logic        rchk_err_unaligned;      // rchk error for unaligned instructions
 
   // Aligned instructions will either be fully in index 0 or incoming data
   // This also applies for the bus_error and mpu_status
@@ -200,8 +200,10 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   // RCHK
   /////////////////
   // Enable any rchk checking when enabled in cpuctrl
-  // PMA integrity bit is parth of bus_resp and will be checked within the rchk module.
-  assign rchk_enable = xsecure_ctrl_i.cpuctrl.integrity;
+  // PMA integrity bit is part of bus_resp and will be checked within the rchk module.
+  // Always check the full rchk (both bits are the same)
+  assign rchk_enable[0] = xsecure_ctrl_i.cpuctrl.integrity;
+  assign rchk_enable[1] = xsecure_ctrl_i.cpuctrl.integrity;
 
   // Rchk for buffer entry q0
   cv32e40s_rchk_check

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -80,7 +80,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   // LSU
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
   input  logic        data_stall_wb_i,            // WB stalled by LSU
-  input  logic [1:0]  lsu_err_wb_i,               // LSU bus error in WB stage
+  input  logic [2:0]  lsu_err_wb_i,               // LSU bus error or integrity error in WB stage
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
   input  logic        lsu_interruptible_i,        // LSU may be interrupted
   input  logic        lsu_valid_wb_i,             // LSU is valid in WB (factors in rvalid from either OBI bus or write buffer)

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -80,7 +80,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   // LSU
   input  mpu_status_e lsu_mpu_status_wb_i,        // MPU status (WB stage)
   input  logic        data_stall_wb_i,            // WB stalled by LSU
-  input  logic [2:0]  lsu_err_wb_i,               // LSU bus error or integrity error in WB stage
+  input  lsu_err_wb_t lsu_err_wb_i,               // LSU bus error or integrity error in WB stage
   input  logic        lsu_busy_i,                 // LSU is busy with outstanding transfers
   input  logic        lsu_interruptible_i,        // LSU may be interrupted
   input  logic        lsu_valid_wb_i,             // LSU is valid in WB (factors in rvalid from either OBI bus or write buffer)

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -70,7 +70,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
   // From WB stage
   input  ex_wb_pipe_t ex_wb_pipe_i,
-  input  logic [1:0]  lsu_err_wb_i,               // LSU caused bus_error in WB stage, gated with data_rvalid_i inside load_store_unit
+  input  logic [2:0]  lsu_err_wb_i,               // LSU caused bus_error or integrity error in WB stage, gated with data_rvalid_i inside load_store_unit
   input  logic        last_op_wb_i,               // WB stage contains the last operation of an instruction
   input  logic        abort_op_wb_i,              // WB stage contains an (to be) aborted instruction or sequence
 
@@ -139,6 +139,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // Sticky version of lsu_err_wb_i
   logic nmi_pending_q;
   logic nmi_is_store_q; // 1 for store, 0 for load
+  logic nmi_is_integrity_q; // 1 for integrity, 0 for bus error
 
   // Debug mode
   logic debug_mode_n;
@@ -639,7 +640,8 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
           ctrl_fsm_o.csr_save_cause  = 1'b1;
           ctrl_fsm_o.csr_cause.irq = 1'b1;
-          ctrl_fsm_o.csr_cause.exception_code = nmi_is_store_q ? INT_CAUSE_LSU_STORE_FAULT : INT_CAUSE_LSU_LOAD_FAULT;
+          ctrl_fsm_o.csr_cause.exception_code = nmi_is_integrity_q ? (nmi_is_store_q ? INT_CAUSE_LSU_STORE_INTEGRITY_FAULT : INT_CAUSE_LSU_LOAD_INTEGRITY_FAULT) :
+                                                                     (nmi_is_store_q ? INT_CAUSE_LSU_STORE_FAULT : INT_CAUSE_LSU_LOAD_FAULT);
 
           // Save pc from oldest valid instruction
           if (ex_wb_pipe_i.instr_valid) begin
@@ -1094,13 +1096,16 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
     if (rst_n == 1'b0) begin
       nmi_pending_q <= 1'b0;
       nmi_is_store_q <= 1'b0;
+      nmi_is_integrity_q <= 1'b0;
     end else begin
-      if (lsu_err_wb_i[0] && !nmi_pending_q) begin
+      // Bus error [0] or integrity error [1]
+      if ((lsu_err_wb_i[0] || lsu_err_wb_i[1]) && !nmi_pending_q) begin
         // Set whenever an error occurs in WB for the LSU, unless we already have an NMI pending.
         // Later errors could overwrite the bit for load/store type, and with mtval the address would be overwritten.
         // todo: if mtval is implemented, address must be sticky as well
         nmi_pending_q <= 1'b1;
-        nmi_is_store_q <= lsu_err_wb_i[1];
+        nmi_is_integrity_q <= lsu_err_wb_i[1];
+        nmi_is_store_q <= lsu_err_wb_i[2];
       // Clear when the controller takes the NMI
       end else if (ctrl_fsm_o.pc_set && (ctrl_fsm_o.pc_mux == PC_TRAP_NMI)) begin
         nmi_pending_q <= 1'b0;

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -264,7 +264,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        lsu_last_op_ex;
   mpu_status_e lsu_mpu_status_wb;
   logic [31:0] lsu_rdata_wb;
-  logic [2:0]  lsu_err_wb;
+  lsu_err_wb_t lsu_err_wb;
 
   logic        lsu_valid_0;             // Handshake with EX
   logic        lsu_ready_ex;

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -306,7 +306,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        csr_err;
   logic        itf_int_err;
   logic        integrity_err_if;
-  logic        integrity_err_lsu;
+  logic        lsu_integrity_err;
 
   // Minor Alert Triggers
   logic        lfsr_lockup;
@@ -478,7 +478,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   //                                 //
   /////////////////////////////////////
 
-  assign itf_int_err     = integrity_err_if || integrity_err_lsu;
+  assign itf_int_err     = integrity_err_if || lsu_integrity_err;
 
   cv32e40s_alert
     alert_i
@@ -792,7 +792,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .valid_1_o             ( lsu_valid_1        ),
     .ready_1_i             ( lsu_ready_wb       ),
 
-    .integrity_err_o       ( integrity_err_lsu  ),
+    .integrity_err_o       ( lsu_integrity_err  ),
 
     .xsecure_ctrl_i        ( xsecure_ctrl       ),
 

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -398,8 +398,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
   assign m_c_obi_instr_if.resp_payload.rdata = instr_rdata_i;
   assign m_c_obi_instr_if.resp_payload.err   = instr_err_i;
   assign m_c_obi_instr_if.resp_payload.rchk  = instr_rchk_i;
-  assign m_c_obi_instr_if.resp_payload.parity_err = 1'b0; // Tie off here, will we populated in instr_obi_insterface.
-  assign m_c_obi_instr_if.resp_payload.rchk_err   = 1'b0; // Tie off here, will we populated in instr_obi_insterface.
+  assign m_c_obi_instr_if.resp_payload.parity_err = 1'b0; // Tie off here, will we populated in instr_obi_interface.
+  assign m_c_obi_instr_if.resp_payload.rchk_err   = 1'b0; // Tie off here, will we populated in instr_obi_interface.
 
   assign data_req_o                          = m_c_obi_data_if.s_req.req;
   assign data_reqpar_o                       = m_c_obi_data_if.s_req.reqpar;
@@ -418,8 +418,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
   assign m_c_obi_data_if.resp_payload.rdata  = data_rdata_i;
   assign m_c_obi_data_if.resp_payload.err    = data_err_i;
   assign m_c_obi_data_if.resp_payload.rchk   = data_rchk_i;
-  assign m_c_obi_data_if.resp_payload.parity_err = 1'b0; // Tie off here, will we populated in data_obi_insterface.
-  assign m_c_obi_data_if.resp_payload.rchk_err   = 1'b0; // Tie off here, will we populated in data_obi_insterface.
+  assign m_c_obi_data_if.resp_payload.parity_err = 1'b0; // Tie off here, will we populated in data_obi_interface.
+  assign m_c_obi_data_if.resp_payload.rchk_err   = 1'b0; // Tie off here, will we populated in data_obi_interface.
 
   assign debug_havereset_o = ctrl_fsm.debug_havereset;
   assign debug_halted_o    = ctrl_fsm.debug_halted;

--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -59,6 +59,8 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   if_c_obi.master     m_c_obi_data_if
 );
 
+localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
+
   typedef struct packed {
     logic        integrity;
     logic        gnterr;
@@ -79,8 +81,8 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   logic       rchk_err;
 
   // Outstanding counter signals
-  logic [1:0]     cnt_q;                        // Transaction counter
-  logic [1:0]     next_cnt;                     // Next value for cnt_q
+  logic [CNT_WIDTH-1:0]     cnt_q;                        // Transaction counter
+  logic [CNT_WIDTH-1:0]     next_cnt;                     // Next value for cnt_q
   logic           count_up;
   logic           count_down;
 

--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -36,7 +36,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
-#(  parameter int          MAX_OUTSTANDING = 2
+#(  parameter int unsigned  MAX_OUTSTANDING   = 2,
+    parameter int unsigned  OUTSTND_CNT_WIDTH = $clog2(MAX_OUTSTANDING+1)
  )
 (
   input  logic        clk,
@@ -55,11 +56,14 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
 
   input xsecure_ctrl_t   xsecure_ctrl_i,
 
+  // outstanding transactions count from LSU response filter
+  input logic [OUTSTND_CNT_WIDTH-1:0] bus_cnt_i,
+
   // OBI interface
   if_c_obi.master     m_c_obi_data_if
 );
 
-localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
+
 
   typedef struct packed {
     logic        integrity;
@@ -67,8 +71,8 @@ localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
     logic        store;
   } fifo_t;
 
-  // FIFO is 1 bit deeper than the maximum value of cnt_q
-  // Index 0 is tied low to enable direct use of cnt_q to pick correct FIFO index.
+  // FIFO is 1 bit deeper than the maximum value of bus_cnt_i
+  // Index 0 is tied low to enable direct use of bus_cnt_i to pick correct FIFO index.
   fifo_t [MAX_OUTSTANDING:0] fifo_q;
   fifo_t fifo_input;
 
@@ -80,13 +84,7 @@ localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
   logic [1:0] rchk_en;                                // Rchk enable. bit0: for bits 3:0, bit1: bit 4 of rchk
   logic       rchk_err;
 
-  // Outstanding counter signals
-  logic [CNT_WIDTH-1:0]     cnt_q;                        // Transaction counter
-  logic [CNT_WIDTH-1:0]     next_cnt;                     // Next value for cnt_q
-  logic           count_up;
-  logic           count_down;
-
-  logic           resp_is_store;
+    logic           resp_is_store;
 
 
   //////////////////////////////////////////////////////////////////////////////
@@ -103,7 +101,7 @@ localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
     resp_o  = m_c_obi_data_if.resp_payload;
     resp_o.parity_err  = rvalidpar_err || gntpar_err_resp;
     resp_o.rchk_err    = rchk_err;
-    resp_o.integrity   = fifo_q[cnt_q].integrity;
+    resp_o.integrity   = fifo_q[bus_cnt_i].integrity;
   end
 
   //////////////////////////////////////////////////////////////////////////////
@@ -139,40 +137,6 @@ localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
 
   assign m_c_obi_data_if.s_req.reqpar = !m_c_obi_data_if.s_req.req;
 
-
-  /////////////////////////////////////////////////////////////
-  // Outstanding transactions counter
-  // Used for tracking parity errors and integrity attribute
-  /////////////////////////////////////////////////////////////
-  assign count_up = m_c_obi_data_if.s_req.req && m_c_obi_data_if.s_gnt.gnt;  // Increment upon accepted transfer request
-  assign count_down = m_c_obi_data_if.s_rvalid.rvalid;                        // Decrement upon accepted transfer response
-
-  always_comb begin
-    case ({count_up, count_down})
-      2'b00 : begin
-        next_cnt = cnt_q;
-      end
-      2'b01 : begin
-        next_cnt = cnt_q - 1'b1;
-      end
-      2'b10 : begin
-        next_cnt = cnt_q + 1'b1;
-      end
-      2'b11 : begin
-        next_cnt = cnt_q;
-      end
-      default:;
-    endcase
-  end
-
-  always_ff @(posedge clk, negedge rst_n)
-  begin
-    if (rst_n == 1'b0) begin
-      cnt_q <= '0;
-    end else begin
-      cnt_q <= next_cnt;
-    end
-  end
 
   /////////////////
   // Integrity
@@ -237,9 +201,9 @@ localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
   );
 
   // grant parity for response is read from the fifo
-  assign gntpar_err_resp = fifo_q[cnt_q].gnterr;
+  assign gntpar_err_resp = fifo_q[bus_cnt_i].gnterr;
 
-  assign resp_is_store = fifo_q[cnt_q].store;
+  assign resp_is_store = fifo_q[bus_cnt_i].store;
 
   // Checking rvalid parity
   // integrity_err_o will go high immediately

--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -36,6 +36,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
+#(  parameter int          MAX_OUTSTANDING = 2
+ )
 (
   input  logic        clk,
   input  logic        rst_n,
@@ -49,9 +51,41 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   output logic           resp_valid_o,          // Note: Consumer is assumed to be 'ready' whenever resp_valid_o = 1
   output obi_data_resp_t resp_o,
 
+  output logic         integrity_err_o,
+
+  input xsecure_ctrl_t   xsecure_ctrl_i,
+
   // OBI interface
   if_c_obi.master     m_c_obi_data_if
 );
+
+  typedef struct packed {
+    logic        integrity;
+    logic        gnterr;
+    logic        store;
+  } fifo_t;
+
+  // FIFO is 1 bit deeper than the maximum value of cnt_q
+  // Index 0 is tied low to enable direct use of cnt_q to pick correct FIFO index.
+  fifo_t [MAX_OUTSTANDING:0] fifo_q;
+  fifo_t fifo_input;
+
+  // Parity and rchk error signals
+  logic       gntpar_err;
+  logic       gntpar_err_q;                           // gnt parity error (sticky for waited grants)
+  logic       rvalidpar_err;                          // rvalid parity error (immediate during response phase)
+  logic       gntpar_err_resp;                        // grant error with reponse timing (output of fifo)
+  logic [1:0] rchk_en;                                // Rchk enable. bit0: for bits 3:0, bit1: bit 4 of rchk
+  logic       rchk_err;
+
+  // Outstanding counter signals
+  logic [1:0]     cnt_q;                        // Transaction counter
+  logic [1:0]     next_cnt;                     // Next value for cnt_q
+  logic           count_up;
+  logic           count_down;
+
+  logic           resp_is_store;
+
 
   //////////////////////////////////////////////////////////////////////////////
   // OBI R Channel
@@ -62,7 +96,13 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   // is always receptive when resp_valid_o = 1 (otherwise a response would get dropped)
 
   assign resp_valid_o = m_c_obi_data_if.s_rvalid.rvalid;
-  assign resp_o       = m_c_obi_data_if.resp_payload;
+
+  always_comb begin
+    resp_o  = m_c_obi_data_if.resp_payload;
+    resp_o.parity_err  = rvalidpar_err || gntpar_err_resp;
+    resp_o.rchk_err    = rchk_err;
+    resp_o.integrity   = fifo_q[cnt_q].integrity;
+  end
 
   //////////////////////////////////////////////////////////////////////////////
   // OBI A Channel
@@ -96,5 +136,113 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   assign trans_ready_o = m_c_obi_data_if.s_gnt.gnt;
 
   assign m_c_obi_data_if.s_req.reqpar = !m_c_obi_data_if.s_req.req;
+
+
+  /////////////////////////////////////////////////////////////
+  // Outstanding transactions counter
+  // Used for tracking parity errors and integrity attribute
+  /////////////////////////////////////////////////////////////
+  assign count_up = m_c_obi_data_if.s_req.req && m_c_obi_data_if.s_gnt.gnt;  // Increment upon accepted transfer request
+  assign count_down = m_c_obi_data_if.s_rvalid.rvalid;                        // Decrement upon accepted transfer response
+
+  always_comb begin
+    case ({count_up, count_down})
+      2'b00 : begin
+        next_cnt = cnt_q;
+      end
+      2'b01 : begin
+        next_cnt = cnt_q - 1'b1;
+      end
+      2'b10 : begin
+        next_cnt = cnt_q + 1'b1;
+      end
+      2'b11 : begin
+        next_cnt = cnt_q;
+      end
+      default:;
+    endcase
+  end
+
+  always_ff @(posedge clk, negedge rst_n)
+  begin
+    if (rst_n == 1'b0) begin
+      cnt_q <= '0;
+    end else begin
+      cnt_q <= next_cnt;
+    end
+  end
+
+  /////////////////
+  // Integrity
+  /////////////////
+
+  // Always check gnt parity
+  // alert_major will not update when in reset
+  assign gntpar_err = (m_c_obi_data_if.s_gnt.gnt == m_c_obi_data_if.s_gnt.gntpar);
+
+  // gntpar_err_q is a sticky gnt error bit.
+  // Any gnt parity error detected during req will be remembered and propagated
+  // to the fifo when the address phase ends.
+  always_ff @ (posedge clk, negedge rst_n) begin
+    if (!rst_n) begin
+      gntpar_err_q <= '0;
+    end
+    else begin
+      if (m_c_obi_data_if.s_req.req) begin
+        // Address phase active, set sticky gntpar_err if not granted
+        // When granted, sticky bit will be cleared for the next address phase
+        if (!m_c_obi_data_if.s_gnt.gnt) begin
+          gntpar_err_q <= gntpar_err || gntpar_err_q;
+        end else begin
+          gntpar_err_q <= 1'b0;
+        end
+      end
+    end
+  end
+
+  // FIFO to keep track of gnt parity errors, integrity bit from PMA and if transaction is load or store for outstanding transactions
+
+  assign fifo_input.integrity = trans_i.integrity;
+  assign fifo_input.gnterr    = (gntpar_err || gntpar_err_q);
+  assign fifo_input.store     = trans_i.we;
+
+  always_ff @ (posedge clk, negedge rst_n) begin
+    if (!rst_n) begin
+      fifo_q <= '0;
+    end
+    else begin
+      if (m_c_obi_data_if.s_req.req && m_c_obi_data_if.s_gnt.gnt) begin
+        // Accepted address phase, populate FIFO with gnt parity error and PMA integrity bit
+        fifo_q <= {fifo_q[MAX_OUTSTANDING-1:1], fifo_input, 3'b000};
+      end
+    end
+  end
+
+  // Enable rchk when in response phase and cpuctrl.integrity is set
+  // Only enable check of bits 3:0 (rchk_en[0]) for loads
+  assign rchk_en[0] = m_c_obi_data_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity && !resp_is_store;
+  assign rchk_en[1] = m_c_obi_data_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity;
+
+  cv32e40s_rchk_check
+  #(
+      .RESP_TYPE (obi_data_resp_t)
+  )
+  rchk_i
+  (
+    .resp_i   (resp_o),  // Using local output, as is has the PMA integrity bit appended from the fifo. Otherwise inputs from bus.
+    .enable_i (rchk_en),
+    .err_o    (rchk_err)
+  );
+
+  // grant parity for response is read from the fifo
+  assign gntpar_err_resp = fifo_q[cnt_q].gnterr;
+
+  assign resp_is_store = fifo_q[cnt_q].store;
+
+  // Checking rvalid parity
+  // integrity_err_o will go high immediately
+  assign rvalidpar_err = (m_c_obi_data_if.s_rvalid.rvalid == m_c_obi_data_if.s_rvalid.rvalidpar);
+
+  assign integrity_err_o = rchk_err || rvalidpar_err || gntpar_err;
 
 endmodule

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -59,6 +59,7 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   if_c_obi.master        m_c_obi_instr_if
 );
 
+  localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
 
   typedef struct packed {
     logic        integrity;
@@ -80,8 +81,8 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   logic gntpar_err_resp;                        // grant error with reponse timing (output of fifo)
 
   // Outstanding counter signals
-  logic [1:0]     cnt_q;                        // Transaction counter
-  logic [1:0]     next_cnt;                     // Next value for cnt_q
+  logic [CNT_WIDTH-1:0]     cnt_q;                        // Transaction counter
+  logic [CNT_WIDTH-1:0]     next_cnt;                     // Next value for cnt_q
   logic           count_up;
   logic           count_down;
 
@@ -294,9 +295,9 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
 
 
   // Enable rchk when in response phase and cpuctrl.integrity is set
-  // Both bits are the same, we always read and always check the fulle rchk
-  assign rchk_en[0] = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity;
-  assign rchk_en[1] = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity;
+  // Both bits are the same, we always read and always check the full rchk
+  assign rchk_en[0] = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity; // Check rdata checksum
+  assign rchk_en[1] = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity; // Check bus error checksum
   cv32e40s_rchk_check
   #(
       .RESP_TYPE (obi_inst_resp_t)

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -85,7 +85,7 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   logic           count_up;
   logic           count_down;
 
-  logic           rchk_en;                      // Enable rchk (rvalid && integrity)
+  logic [1:0]     rchk_en;                      // Enable rchk (rvalid && integrity)
   logic           rchk_err;                     // Local rchk error signal
 
   //////////////////////////////////////////////////////////////////////////////
@@ -294,7 +294,9 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
 
 
   // Enable rchk when in response phase and cpuctrl.integrity is set
-  assign rchk_en = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity;
+  // Both bits are the same, we always read and always check the fulle rchk
+  assign rchk_en[0] = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity;
+  assign rchk_en[1] = m_c_obi_instr_if.s_rvalid.rvalid && xsecure_ctrl_i.cpuctrl.integrity;
   cv32e40s_rchk_check
   #(
       .RESP_TYPE (obi_inst_resp_t)

--- a/rtl/cv32e40s_load_store_unit.sv
+++ b/rtl/cv32e40s_load_store_unit.sv
@@ -55,7 +55,7 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   output logic        lsu_last_op_0_o,          // Last operation is active in EX
 
   // Stage 1 outputs (WB)
-  output logic [1:0]  lsu_err_1_o,
+  output logic [2:0]  lsu_err_1_o,
   output logic [31:0] lsu_rdata_1_o,            // LSU read data
   output mpu_status_e lsu_mpu_status_1_o,       // MPU (PMA) status, response/WB timing. To controller and wb_stage
 
@@ -75,6 +75,11 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   output logic        ready_1_o,                // LSU ready for new data in WB stage
   output logic        valid_1_o,
   input  logic        ready_1_i,
+
+  // Integrity error - fans into alert_majort_o
+  output logic        integrity_err_o,
+
+  input xsecure_ctrl_t   xsecure_ctrl_i,
 
   // eXtension interface
   if_xif.cpu_mem        xif_mem_if,
@@ -106,7 +111,7 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   obi_data_req_t  filter_trans;
   logic           filter_resp_valid;
   obi_data_resp_t filter_resp;
-  logic [1:0]     filter_err;
+  logic [2:0]     filter_err;
 
   // Transaction request (from cv32e40s_write_buffer to cv32e40s_data_obi_interface)
   logic           bus_trans_valid;
@@ -700,6 +705,9 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   //////////////////////////////////////////////////////////////////////////////
 
   cv32e40s_data_obi_interface
+  #(
+      .MAX_OUTSTANDING (2) // todo: connect to parameter
+  )
   data_obi_i
   (
     .clk                ( clk             ),
@@ -712,6 +720,9 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
     .resp_valid_o       ( bus_resp_valid  ),
     .resp_o             ( bus_resp        ),
 
+    .integrity_err_o    ( integrity_err_o ),
+
+    .xsecure_ctrl_i     ( xsecure_ctrl_i  ),
     .m_c_obi_data_if    ( m_c_obi_data_if )
   );
 

--- a/rtl/cv32e40s_lsu_response_filter.sv
+++ b/rtl/cv32e40s_lsu_response_filter.sv
@@ -32,7 +32,10 @@
 
 module cv32e40s_lsu_response_filter
   import cv32e40s_pkg::*;
-  #(parameter DEPTH = 2)
+  #(
+      parameter               DEPTH             = 2,
+      parameter int unsigned  OUTSTND_CNT_WIDTH = $clog2(DEPTH+1)
+  )
   (
    // clock and reset
    input logic            clk,
@@ -55,9 +58,11 @@ module cv32e40s_lsu_response_filter
    output logic           resp_valid_o,
    output obi_data_resp_t resp_o, // Todo: This also carries the obi error field. Could replace by data_resp_t
 
+   output logic [OUTSTND_CNT_WIDTH-1:0] bus_cnt_o,
+
    // Todo: This error signal could be merged with mpu_status_e, and be signaled via the resp_o above (if replaced by data_resp_t).
    //       This would make the error flow all the way through the MPU and not bypass the MPU as it does now.
-   output logic [2:0]     err_o  // bit0: flag for bus error, bit1: flag for integrity error, bit2: type (1 for store, 0 for load)
+   output lsu_err_wb_t    err_o   // error conditions in WB part of LSU
    );
 
   localparam CNT_WIDTH = $clog2(DEPTH+1);
@@ -168,13 +173,16 @@ module cv32e40s_lsu_response_filter
   assign trans_o      = trans_i;
 
   // Signal bus error
-  assign err_o[0] = resp_valid_i && resp_i.err;
+  assign err_o.bus_err = resp_valid_i && resp_i.err;
   // Signal integrity error, only signal rchk_err for loads
-  assign err_o[1] = resp_valid_i && (resp_i.parity_err || resp_i.rchk_err);
+  assign err_o.integrity_err = resp_valid_i && (resp_i.parity_err || resp_i.rchk_err);
   // Signal type transaction for error (load or store)
-  assign err_o[2] = outstanding_q[bus_cnt_q].store;
+  assign err_o.store = outstanding_q[bus_cnt_q].store;
 
   // bus_resp goes straight through
   assign resp_o = resp_i;
+
+  // Export bus side counter for use outside of this module
+  assign bus_cnt_o = bus_cnt_q;
 
 endmodule

--- a/rtl/cv32e40s_rchk_check.sv
+++ b/rtl/cv32e40s_rchk_check.sv
@@ -27,6 +27,8 @@
 //                                                                            //
 // Description:    This module will check the recomputed rchk values          //
 //                 and signal an error if enabled and checksums does not match//
+//                 The enable signal is split in two, one for checking rdata  //
+//                 for reads, and one to check the error bit (read and writes)//
 ////////////////////////////////////////////////////////////////////////////////
 
 

--- a/rtl/cv32e40s_rchk_check.sv
+++ b/rtl/cv32e40s_rchk_check.sv
@@ -26,7 +26,7 @@
 // Language:       SystemVerilog                                              //
 //                                                                            //
 // Description:    This module will check the recomputed rchk values          //
-//                 and signal an error if enalbed and checksums does not match//
+//                 and signal an error if enabled and checksums does not match//
 ////////////////////////////////////////////////////////////////////////////////
 
 
@@ -35,12 +35,15 @@ module cv32e40s_rchk_check import cv32e40s_pkg::*;
   parameter type RESP_TYPE = obi_inst_resp_t
 )
 (
-  input  RESP_TYPE resp_i,
-  input  logic     enable_i,
-  output logic     err_o
+  input  RESP_TYPE   resp_i,
+  input  logic [1:0] enable_i,
+  output logic       err_o
 );
 
 logic [4:0] rchk_res;
+
+logic rdata_err;
+logic err_err;
 
 // Compute rchk from response inputs
 always_comb begin
@@ -53,6 +56,8 @@ always_comb begin
   };
 end
 
-assign err_o = (enable_i && resp_i.integrity)? (rchk_res != resp_i.rchk) : 1'b0;
+assign rdata_err = (enable_i[0] && resp_i.integrity) ? (rchk_res[3:0] != resp_i.rchk[3:0]) : 1'b0;
+assign err_err   = (enable_i[1] && resp_i.integrity) ? (rchk_res[4] != resp_i.rchk[4]) : 1'b0;
+assign err_o = rdata_err || err_err;
 
 endmodule

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1113,9 +1113,9 @@ typedef struct packed {
   logic [INSTR_DATA_WIDTH-1:0] rdata;
   logic                        err;
   logic [4:0]                  rchk;
-  logic                        rchk_err;
-  logic                        parity_err;
-  logic                        integrity;
+  logic                        rchk_err;    // Calculated in instr_obi_interface and appended to struct upon rvalid
+  logic                        parity_err;  // Calculated in instr_obi_interface and appended to struct upon rvalid
+  logic                        integrity;   // Tracked through instr_obi_interface and appended to struct upon rvalid
 } obi_inst_resp_t;
 
 typedef struct packed {
@@ -1134,9 +1134,9 @@ typedef struct packed {
   logic [DATA_DATA_WIDTH-1:0] rdata;
   logic                       err;
   logic [4:0]                 rchk;
-  logic                       rchk_err;
-  logic                       parity_err;
-  logic                       integrity;
+  logic                       rchk_err;    // Calculated in data_obi_interface and appended to struct upon rvalid
+  logic                       parity_err;  // Calculated in data_obi_interface and appended to struct upon rvalid
+  logic                       integrity;   // Tracked through data_obi_interface and appended to struct upon rvalid
 } obi_data_resp_t;
 
 // Data/instruction transfer bundeled with MPU status

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -955,8 +955,10 @@ parameter EXC_CAUSE_ECALL_MMODE           = 11'h0B;
 parameter EXC_CAUSE_INSTR_INTEGRITY_FAULT = 11'h19;
 parameter EXC_CAUSE_INSTR_BUS_FAULT       = 11'h30;
 
-parameter INT_CAUSE_LSU_LOAD_FAULT  = 11'h400;
-parameter INT_CAUSE_LSU_STORE_FAULT = 11'h401;
+parameter INT_CAUSE_LSU_LOAD_FAULT            = 11'h400;
+parameter INT_CAUSE_LSU_STORE_FAULT           = 11'h401;
+parameter INT_CAUSE_LSU_LOAD_INTEGRITY_FAULT  = 11'h402;
+parameter INT_CAUSE_LSU_STORE_INTEGRITY_FAULT = 11'h403;
 
 // Interrupt mask
 parameter IRQ_MASK = 32'hFFFF0888;
@@ -1132,6 +1134,9 @@ typedef struct packed {
   logic [DATA_DATA_WIDTH-1:0] rdata;
   logic                       err;
   logic [4:0]                 rchk;
+  logic                       rchk_err;
+  logic                       parity_err;
+  logic                       integrity;
 } obi_data_resp_t;
 
 // Data/instruction transfer bundeled with MPU status

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1206,6 +1206,13 @@ typedef struct packed
   logic        accepted;  // Was the offloaded instruction accepted or not?
 } xif_meta_t;
 
+typedef struct packed
+{
+  logic        bus_err;
+  logic        integrity_err;
+  logic        store;
+} lsu_err_wb_t;
+
 // IF/ID pipeline
 typedef struct packed {
   logic        instr_valid;

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -228,7 +228,7 @@ module cv32e40s_controller_fsm_sva
   // Todo: Modify to account for response filter (bufferable writes)
   //a_lsu_err_wb :
   //  assert property (@(posedge clk) disable iff (!rst_n)
-  //          lsu_err_wb_i[0] |-> ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en)
+  //          lsu_err_wb_i[0] || lsu_err_wb_i[1] |-> ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en)
   //    else `uvm_error("controller", "lsu_error in WB with no valid LSU instruction")
 
   // Check that fencei handshake is only exersiced when there's a fencei in the writeback stage

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -61,7 +61,7 @@ module cv32e40s_controller_fsm_sva
   input logic           csr_illegal_i,
   input logic           pending_single_step,
   input logic           trigger_match_in_wb,
-  input logic [2:0]     lsu_err_wb_i,
+  input lsu_err_wb_t    lsu_err_wb_i,
   input logic           wb_valid_i,
   input logic           fencei_in_wb,
   input logic           fencei_flush_req_o,
@@ -228,7 +228,7 @@ module cv32e40s_controller_fsm_sva
   // Todo: Modify to account for response filter (bufferable writes)
   //a_lsu_err_wb :
   //  assert property (@(posedge clk) disable iff (!rst_n)
-  //          lsu_err_wb_i[0] || lsu_err_wb_i[1] |-> ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en)
+  //          lsu_err_wb_i.bus_err || lsu_err_wb_i.integrity_err |-> ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.lsu_en)
   //    else `uvm_error("controller", "lsu_error in WB with no valid LSU instruction")
 
   // Check that fencei handshake is only exersiced when there's a fencei in the writeback stage

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -61,7 +61,7 @@ module cv32e40s_controller_fsm_sva
   input logic           csr_illegal_i,
   input logic           pending_single_step,
   input logic           trigger_match_in_wb,
-  input logic [1:0]     lsu_err_wb_i,
+  input logic [2:0]     lsu_err_wb_i,
   input logic           wb_valid_i,
   input logic           fencei_in_wb,
   input logic           fencei_flush_req_o,

--- a/sva/cv32e40s_data_obi_interface_sva.sv
+++ b/sva/cv32e40s_data_obi_interface_sva.sv
@@ -1,0 +1,169 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// This file, and derivatives thereof are licensed under the
+// Solderpad License, Version 2.0 (the "License");
+// Use of this file means you agree to the terms and conditions
+// of the license and are in full compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/SHL-2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// and hardware implementations thereof
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESSED OR IMPLIED.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// Authors:        Oystein Knauserud - oystein.knauserud@silabs.com           //
+//                                                                            //
+// Description:    RTL assertions for the data_obi_interface module           //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+module cv32e40s_data_obi_interface_sva
+  import uvm_pkg::*;
+  import cv32e40s_pkg::*;
+(
+  input logic           clk,
+  input logic           rst_n,
+  if_c_obi.monitor      m_c_obi_data_if,
+  input logic           gntpar_err,
+  input logic           gntpar_err_q,
+  input obi_data_resp_t resp_o,
+  input obi_data_req_t  trans_i,
+  input logic           gntpar_err_resp,
+  input logic           resp_is_store
+);
+
+ // Support logic (FIFO) to track grant parity fault
+
+localparam MAX_OUTSTND_TXN = 5; // This needs to be larger (or equal) to the max outstanding transactions in IF and LSU
+
+typedef enum logic [1:0] {GNT_ERR, GNT_NOERR, GNT_NONE} gnt_err_chck_e;
+typedef enum logic [1:0] {INT, NOINT, INT_NONE} integrity_e;
+typedef enum logic [1:0] {STORE, LOAD, STORE_NONE} store_e;
+logic exp_int;
+logic exp_gnt_err;
+logic exp_store;
+logic [$clog2(MAX_OUTSTND_TXN)-1:0] oldest_txn;
+
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] gnt_fifo_q;
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] gnt_fifo_n;
+gnt_err_chck_e [MAX_OUTSTND_TXN-1:0] gnt_fifo_tmp;
+
+integrity_e [MAX_OUTSTND_TXN-1:0] int_fifo_q;
+integrity_e [MAX_OUTSTND_TXN-1:0] int_fifo_n;
+integrity_e [MAX_OUTSTND_TXN-1:0] int_fifo_tmp;
+
+store_e [MAX_OUTSTND_TXN-1:0] store_fifo_q;
+store_e [MAX_OUTSTND_TXN-1:0] store_fifo_n;
+store_e [MAX_OUTSTND_TXN-1:0] store_fifo_tmp;
+
+always_comb begin
+  gnt_fifo_n   = gnt_fifo_q;
+  gnt_fifo_tmp = gnt_fifo_q;
+  int_fifo_n   = int_fifo_q;
+  int_fifo_tmp = int_fifo_q;
+  store_fifo_n = store_fifo_q;
+  store_fifo_tmp = store_fifo_q;
+  casez ({m_c_obi_data_if.s_req.req, m_c_obi_data_if.s_gnt.gnt, m_c_obi_data_if.s_rvalid.rvalid})
+      3'b110: begin
+        // Accepted address phase, add one entry to FIFO
+        gnt_fifo_n = (gntpar_err || gntpar_err_q) ?
+                               {gnt_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
+                               {gnt_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
+
+        int_fifo_n = trans_i.integrity ?
+                               {int_fifo_q[MAX_OUTSTND_TXN-2:0], INT} :
+                               {int_fifo_q[MAX_OUTSTND_TXN-2:0], NOINT};
+
+        store_fifo_n = trans_i.we ?
+                               {store_fifo_q[MAX_OUTSTND_TXN-2:0], STORE} :
+                               {store_fifo_q[MAX_OUTSTND_TXN-2:0], LOAD};
+      end
+      3'b0?1, 3'b?01: begin
+        // Response phase, remove oldest entry from FIFO
+        gnt_fifo_n[oldest_txn] = GNT_NONE;
+
+        int_fifo_n[oldest_txn] = INT_NONE;
+
+        store_fifo_n[oldest_txn] = STORE_NONE;
+      end
+      3'b111: begin
+        // Accepted address phase and response phase. Clear oldest transaction and add new to FIFO
+        gnt_fifo_tmp[oldest_txn] = GNT_NONE;
+        gnt_fifo_n = (gntpar_err || gntpar_err_q) ?
+                               {gnt_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
+                               {gnt_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
+
+        int_fifo_tmp[oldest_txn] = INT_NONE;
+        int_fifo_n = trans_i.integrity ?
+                                {int_fifo_tmp[MAX_OUTSTND_TXN-2:0], INT} :
+                                {int_fifo_tmp[MAX_OUTSTND_TXN-2:0], NOINT};
+
+        store_fifo_tmp[oldest_txn] = STORE_NONE;
+        store_fifo_n = trans_i.we ?
+                                {store_fifo_tmp[MAX_OUTSTND_TXN-2:0], STORE} :
+                                {store_fifo_tmp[MAX_OUTSTND_TXN-2:0], LOAD};
+      end
+      default; // Do nothing
+    endcase
+end
+
+// FIFO
+always_ff @ (posedge clk, negedge rst_n) begin
+  if (!rst_n) begin
+    gnt_fifo_q <= {MAX_OUTSTND_TXN{GNT_NONE}};
+    int_fifo_q <= {MAX_OUTSTND_TXN{INT_NONE}};
+    store_fifo_q <= {MAX_OUTSTND_TXN{STORE_NONE}};
+  end
+  else begin
+    gnt_fifo_q <= gnt_fifo_n;
+    int_fifo_q <= int_fifo_n;
+    store_fifo_q <= store_fifo_n;
+  end
+end
+
+// Locate oldest entry in FIFO
+// FIFOs for gnt error and integrity bit operate on the same control signals,
+// picking oldest index from gnt fifo.
+always_comb begin
+  oldest_txn = '0;
+  for (int i = 0;  i < MAX_OUTSTND_TXN; i++) begin
+    if (gnt_fifo_q[i] != GNT_NONE) begin
+      oldest_txn = i;
+    end
+  end
+end
+
+// GNT error from the oldest transaction
+assign exp_gnt_err = (gnt_fifo_q[oldest_txn] == GNT_ERR);
+
+// Assert that grant error bit comes out in order
+a_data_obi_gnt_fifo :
+  assert property (@(posedge clk) disable iff (!rst_n)
+                   m_c_obi_data_if.s_rvalid.rvalid |-> exp_gnt_err == gntpar_err_resp)
+    else `uvm_error("mpu", "GNT error bit not correct")
+
+
+// GNT error from the oldest transaction
+assign exp_int = (int_fifo_q[oldest_txn] == INT);
+
+// Assert that trans integrity bit comes out in order
+a_data_obi_int_fifo :
+  assert property (@(posedge clk) disable iff (!rst_n)
+                   m_c_obi_data_if.s_rvalid.rvalid |-> exp_int == resp_o.integrity)
+    else `uvm_error("mpu", "Integrity bit not correct")
+
+// Store bit from the oldest transaction
+assign exp_store = (store_fifo_q[oldest_txn] == STORE);
+
+// Assert that trans integrity bit comes out in order
+a_data_obi_store_fifo :
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    m_c_obi_data_if.s_rvalid.rvalid |-> exp_store == resp_is_store)
+    else `uvm_error("mpu", "Store bit not correct")
+endmodule

--- a/sva/cv32e40s_rvfi_sva.sv
+++ b/sva/cv32e40s_rvfi_sva.sv
@@ -197,7 +197,8 @@ end
                      (no_debug && $stable(mtvec_addr_i)) throughout s_goto_next_rvfi_valid(rvfi_csr_dcsr_rdata[3]) |->
                      rvfi_intr.intr &&
                      (rvfi_pc_rdata == {mtvec_addr_i, NMI_MTVEC_INDEX, 2'b00}) &&
-                     ((rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_FAULT)))
+                     ((rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_FAULT) ||
+                     (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_LOAD_INTEGRITY_FAULT) || (rvfi_csr_mcause_rdata[10:0] == INT_CAUSE_LSU_STORE_INTEGRITY_FAULT)))
       else `uvm_error("rvfi", "dcsr.nmip not followed by rvfi_intr and NMI handler")
 
   /* todo: add back in


### PR DESCRIPTION
LSU will signal intergrity_err_o (fans into alert_major_o) immediately when any parity error on data_gnt_i or data_rvalid_i is detected. Similarly for errors on data_rchk_i, an integrity_err_o will be flagged if cpuctrl.integrity is set and the transaction is from a PMA region with integrity enabled.

Any load or store with integrity errors as described above will generate an NMI.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>