### PR TITLE
Added separate OBI data interface counter for outstanding transaction.

### DIFF
--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -60,7 +60,6 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   if_c_obi.master     m_c_obi_data_if
 );
 
-  localparam OUTSTND_CNT_WIDTH = $clog2(MAX_OUTSTANDING+1);
 
   // Parity and rchk error signals
   logic       gntpar_err;
@@ -132,7 +131,6 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   cv32e40s_obi_integrity_fifo
     #(
         .MAX_OUTSTANDING   (MAX_OUTSTANDING  ),
-        .OUTSTND_CNT_WIDTH (OUTSTND_CNT_WIDTH),
         .RESP_TYPE         (obi_data_resp_t  )
      )
     integrity_fifo_i

--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -70,12 +70,6 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
 
   logic       integrity_resp;
 
-  // Outstanding counter signals
-  logic [OUTSTND_CNT_WIDTH-1:0] cnt_q;                        // Transaction counter
-  logic [OUTSTND_CNT_WIDTH-1:0] next_cnt;                     // Next value for cnt_q
-  logic                         count_up;
-  logic                         count_down;
-
 
   //////////////////////////////////////////////////////////////////////////////
   // OBI R Channel
@@ -126,40 +120,6 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
 
   assign m_c_obi_data_if.s_req.reqpar = !m_c_obi_data_if.s_req.req;
 
-  /////////////////////////////////////////////////////////////
-  // Outstanding transactions counter
-  // Used for tracking parity errors and integrity attribute
-  /////////////////////////////////////////////////////////////
-  assign count_up = m_c_obi_data_if.s_req.req && m_c_obi_data_if.s_gnt.gnt;  // Increment upon accepted transfer request
-  assign count_down = m_c_obi_data_if.s_rvalid.rvalid;                       // Decrement upon accepted transfer response
-
-  always_comb begin
-    case ({count_up, count_down})
-      2'b00 : begin
-        next_cnt = cnt_q;
-      end
-      2'b01 : begin
-        next_cnt = cnt_q - 1'b1;
-      end
-      2'b10 : begin
-        next_cnt = cnt_q + 1'b1;
-      end
-      2'b11 : begin
-        next_cnt = cnt_q;
-      end
-      default:;
-    endcase
-  end
-
-  always_ff @(posedge clk, negedge rst_n)
-  begin
-    if (rst_n == 1'b0) begin
-      cnt_q <= '0;
-    end else begin
-      cnt_q <= next_cnt;
-    end
-  end
-
 
   /////////////////
   // Integrity
@@ -189,8 +149,6 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
 
       // Xsecure
       .xsecure_ctrl_i     (xsecure_ctrl_i     ),
-
-      .bus_cnt_i          (cnt_q              ),
 
       // Response phase properties
       .gntpar_err_resp_o  (gntpar_err_resp    ),

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -59,8 +59,6 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   if_c_obi.master        m_c_obi_instr_if
 );
 
-  localparam CNT_WIDTH = $clog2(MAX_OUTSTANDING + 1);
-
 
   obi_if_state_e state_q, next_state;
 
@@ -208,7 +206,6 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   cv32e40s_obi_integrity_fifo
   #(
       .MAX_OUTSTANDING   (MAX_OUTSTANDING),
-      .OUTSTND_CNT_WIDTH (CNT_WIDTH      ),
       .RESP_TYPE         (obi_inst_resp_t)
    )
   integrity_fifo_i

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -72,12 +72,6 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   logic                 rchk_err_resp;                // Local rchk error signal
   logic                 integrity_resp;               // Response has integrity bit set (from fifo)
 
-  // Outstanding counter signals
-  logic [CNT_WIDTH-1:0] cnt_q;                        // Transaction counter
-  logic [CNT_WIDTH-1:0] next_cnt;                     // Next value for cnt_q
-  logic                 count_up;
-  logic                 count_down;
-
 
   //////////////////////////////////////////////////////////////////////////////
   // OBI R Channel
@@ -202,40 +196,6 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   // the number of outstanding transactions in any way.
   assign trans_ready_o = (state_q == TRANSPARENT);
 
-  /////////////////////////////////////////////////////////////
-  // Outstanding transactions counter
-  // Used for tracking parity errors and integrity attribute
-  /////////////////////////////////////////////////////////////
-  assign count_up = m_c_obi_instr_if.s_req.req && m_c_obi_instr_if.s_gnt.gnt;  // Increment upon accepted transfer request
-  assign count_down = m_c_obi_instr_if.s_rvalid.rvalid;                        // Decrement upon accepted transfer response
-
-  always_comb begin
-    case ({count_up, count_down})
-      2'b00 : begin
-        next_cnt = cnt_q;
-      end
-      2'b01 : begin
-        next_cnt = cnt_q - 1'b1;
-      end
-      2'b10 : begin
-        next_cnt = cnt_q + 1'b1;
-      end
-      2'b11 : begin
-        next_cnt = cnt_q;
-      end
-      default:;
-    endcase
-  end
-
-  always_ff @(posedge clk, negedge rst_n)
-  begin
-    if (rst_n == 1'b0) begin
-      cnt_q <= '0;
-    end else begin
-      cnt_q <= next_cnt;
-    end
-  end
-
   //////////////////////////////////////
   // Track parity errors
   //////////////////////////////////////
@@ -265,8 +225,6 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
 
     // Xsecure
     .xsecure_ctrl_i     (xsecure_ctrl_i                   ),
-
-    .bus_cnt_i          (cnt_q                            ),
 
     // Response phase properties
     .gntpar_err_resp_o  (gntpar_err_resp                  ),

--- a/rtl/cv32e40s_load_store_unit.sv
+++ b/rtl/cv32e40s_load_store_unit.sv
@@ -131,8 +131,6 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   logic                             cnt_is_one_next;
 
 
-  logic [OUTSTND_CNT_WIDTH-1:0]     bus_cnt;              // Transaction counter (bus side of response filter)
-
   logic           ctrl_update;          // Update load/store control info in WB stage
 
   // registers for data_rdata alignment and sign extension
@@ -680,9 +678,7 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
        .ready_i      ( buffer_trans_ready ),
        .trans_o      ( buffer_trans       ),
        .resp_valid_i ( bus_resp_valid     ),
-       .resp_i       ( bus_resp           ),
-
-       .bus_cnt_o    ( bus_cnt            )
+       .resp_i       ( bus_resp           )
 
      );
 
@@ -716,7 +712,7 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
 
   cv32e40s_data_obi_interface
   #(
-      .OUTSTND_CNT_WIDTH (OUTSTND_CNT_WIDTH)
+      .MAX_OUTSTANDING (DEPTH)
   )
   data_obi_i
   (
@@ -731,8 +727,6 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
     .resp_o             ( bus_resp        ),
 
     .integrity_err_o    ( integrity_err_o ),
-
-    .bus_cnt_i          ( bus_cnt         ),
 
     .xsecure_ctrl_i     ( xsecure_ctrl_i  ),
     .m_c_obi_data_if    ( m_c_obi_data_if )

--- a/rtl/cv32e40s_lsu_response_filter.sv
+++ b/rtl/cv32e40s_lsu_response_filter.sv
@@ -58,7 +58,6 @@ module cv32e40s_lsu_response_filter
    output logic           resp_valid_o,
    output obi_data_resp_t resp_o, // Todo: This also carries the obi error field. Could replace by data_resp_t
 
-   output logic [OUTSTND_CNT_WIDTH-1:0] bus_cnt_o,
 
    // Todo: This error signal could be merged with mpu_status_e, and be signaled via the resp_o above (if replaced by data_resp_t).
    //       This would make the error flow all the way through the MPU and not bypass the MPU as it does now.
@@ -181,8 +180,5 @@ module cv32e40s_lsu_response_filter
 
   // bus_resp goes straight through
   assign resp_o = resp_i;
-
-  // Export bus side counter for use outside of this module
-  assign bus_cnt_o = bus_cnt_q;
 
 endmodule

--- a/rtl/cv32e40s_obi_integrity_fifo.sv
+++ b/rtl/cv32e40s_obi_integrity_fifo.sv
@@ -32,7 +32,6 @@
 
 module cv32e40s_obi_integrity_fifo import cv32e40s_pkg::*;
 #(  parameter int unsigned  MAX_OUTSTANDING   = 2,
-    parameter int unsigned  OUTSTND_CNT_WIDTH = $clog2(MAX_OUTSTANDING+1),
     parameter type RESP_TYPE = obi_inst_resp_t
  )
 (
@@ -62,7 +61,7 @@ module cv32e40s_obi_integrity_fifo import cv32e40s_pkg::*;
 
 );
 
-
+  localparam OUTSTND_CNT_WIDTH = $clog2(MAX_OUTSTANDING+1);
 
   typedef struct packed {
     logic        integrity;


### PR DESCRIPTION
Added separate counter for outstanding transaction in data_obi_interface.

The counter previously used (from the lsu_respnse_filter) cannot be used in the case where a transfer happens for a region with both integrity and bufferable set. Then the outstanding counter can be manipulated by the write_buffer - thus the obi interface needs it own counter to know the state of the bus outside of the write buffer.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>