### PR TITLE
OBI protocol hardening

### DIFF
--- a/rtl/cv32e40s_alert.sv
+++ b/rtl/cv32e40s_alert.sv
@@ -42,6 +42,7 @@ module cv32e40s_alert
    input logic      pc_err_i,
    input logic      csr_err_i,
    input logic      itf_int_err_i,
+   input logic      itf_prot_err_i,
    input logic      lfsr_lockup_i,
 
    // Alert outputs
@@ -60,10 +61,11 @@ module cv32e40s_alert
       alert_minor_o <=  ctrl_fsm_i.exception_alert_minor || // Trigger condtion constructed in controller FSM
                         lfsr_lockup_i;                // LFSR lockup
       // Major Alert
-      alert_major_o <= rf_ecc_err_i  || // Register File ECC Error
-                       pc_err_i      || // Program Counter Error
-                       csr_err_i     || // Control ans Status Register Parity Error
-                       itf_int_err_i || // Interface Integrity Error or protocol error
+      alert_major_o <= rf_ecc_err_i   || // Register File ECC Error
+                       pc_err_i       || // Program Counter Error
+                       csr_err_i      || // Control and Status Register Parity Error
+                       itf_int_err_i  || // Interface Integrity Error
+                       itf_prot_err_i || // Interface protocol error
                        ctrl_fsm_i.exception_alert_major; // Instruction integrity error exception
 
     end

--- a/rtl/cv32e40s_alert.sv
+++ b/rtl/cv32e40s_alert.sv
@@ -63,7 +63,7 @@ module cv32e40s_alert
       alert_major_o <= rf_ecc_err_i  || // Register File ECC Error
                        pc_err_i      || // Program Counter Error
                        csr_err_i     || // Control ans Status Register Parity Error
-                       itf_int_err_i || // Interface Integrity Error
+                       itf_int_err_i || // Interface Integrity Error or protocol error
                        ctrl_fsm_i.exception_alert_major; // Instruction integrity error exception
 
     end

--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -63,7 +63,10 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   output privlvl_t                   instr_priv_lvl_o,
   output logic                       instr_is_clic_ptr_o,
   output logic                       instr_is_tbljmp_ptr_o,
-  output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o
+  output logic [ALBUF_CNT_WIDTH-1:0] outstnd_cnt_q_o,
+
+  // Protocol error output
+  output logic           protocol_err_o
 );
 
   // Counter for number of instructions in the FIFO
@@ -665,4 +668,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 
   // Signal that a pointer is about to be fetched
   assign fetch_ptr_access_o = (ctrl_fsm_i.pc_set && (ctrl_fsm_i.pc_set_clicv || ctrl_fsm_i.pc_set_tbljmp));
+
+  // Set protocol error
+  assign protocol_err_o = resp_valid_i && !(|outstanding_cnt_q);
 endmodule

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -308,8 +308,11 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        pc_err_if;
   logic        csr_err;
   logic        itf_int_err;
-  logic        alert_major_if;
-  logic        lsu_alert_major;
+  logic        itf_prot_err;
+  logic        integrity_err_if;
+  logic        protocol_err_if;
+  logic        lsu_integrity_err;
+  logic        lsu_protocol_err;
 
   // Minor Alert Triggers
   logic        lfsr_lockup;
@@ -481,7 +484,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
   //                                 //
   /////////////////////////////////////
 
-  assign itf_int_err     = alert_major_if || lsu_alert_major;
+  assign itf_int_err     = integrity_err_if || lsu_integrity_err;
+  assign itf_prot_err    = protocol_err_if  || lsu_protocol_err;
 
   cv32e40s_alert
     alert_i
@@ -494,6 +498,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
        .pc_err_i            ( pc_err_if         ),
        .csr_err_i           ( csr_err           ),
        .itf_int_err_i       ( itf_int_err       ),
+       .itf_prot_err_i      ( itf_prot_err      ),
        .lfsr_lockup_i       ( lfsr_lockup       ),
 
        // Trigger Outputs
@@ -586,7 +591,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .xsecure_ctrl_i      ( xsecure_ctrl             ),
     .lfsr_shift_o        ( lfsr_shift_if            ),
 
-    .alert_major_o       ( alert_major_if           ),
+    .integrity_err_o     ( integrity_err_if         ),
+    .protocol_err_o      ( protocol_err_if          ),
 
     // eXtension interface
     .xif_compressed_if   ( xif.cpu_compressed       ),
@@ -795,7 +801,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .valid_1_o             ( lsu_valid_1        ),
     .ready_1_i             ( lsu_ready_wb       ),
 
-    .alert_major_o         ( lsu_alert_major     ),
+    .integrity_err_o       ( lsu_integrity_err  ),
+    .protocol_err_o        ( lsu_protocol_err   ),
 
     .xsecure_ctrl_i        ( xsecure_ctrl       ),
 

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -308,8 +308,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        pc_err_if;
   logic        csr_err;
   logic        itf_int_err;
-  logic        integrity_err_if;
-  logic        lsu_integrity_err;
+  logic        alert_major_if;
+  logic        lsu_alert_major;
 
   // Minor Alert Triggers
   logic        lfsr_lockup;
@@ -481,7 +481,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
   //                                 //
   /////////////////////////////////////
 
-  assign itf_int_err     = integrity_err_if || lsu_integrity_err;
+  assign itf_int_err     = alert_major_if || lsu_alert_major;
 
   cv32e40s_alert
     alert_i
@@ -586,7 +586,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .xsecure_ctrl_i      ( xsecure_ctrl             ),
     .lfsr_shift_o        ( lfsr_shift_if            ),
 
-    .integrity_err_o     ( integrity_err_if         ),
+    .alert_major_o       ( alert_major_if           ),
 
     // eXtension interface
     .xif_compressed_if   ( xif.cpu_compressed       ),
@@ -795,7 +795,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .valid_1_o             ( lsu_valid_1        ),
     .ready_1_i             ( lsu_ready_wb       ),
 
-    .integrity_err_o       ( lsu_integrity_err  ),
+    .alert_major_o         ( lsu_alert_major     ),
 
     .xsecure_ctrl_i        ( xsecure_ctrl       ),
 

--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -52,7 +52,8 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   output logic           resp_valid_o,          // Note: Consumer is assumed to be 'ready' whenever resp_valid_o = 1
   output obi_data_resp_t resp_o,
 
-  output logic           alert_major_o,
+  output logic           integrity_err_o,
+  output logic           protocol_err_o,
 
   input xsecure_ctrl_t   xsecure_ctrl_i,
 
@@ -168,6 +169,7 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   // alert_major_o will go high immediately
   assign rvalidpar_err_resp = (m_c_obi_data_if.s_rvalid.rvalid == m_c_obi_data_if.s_rvalid.rvalidpar);
 
-  assign alert_major_o = rchk_err_resp || rvalidpar_err_resp || gntpar_err || protocol_err;
+  assign integrity_err_o = rchk_err_resp || rvalidpar_err_resp || gntpar_err;
+  assign protocol_err_o  = protocol_err;
 
 endmodule

--- a/rtl/cv32e40s_data_obi_interface.sv
+++ b/rtl/cv32e40s_data_obi_interface.sv
@@ -52,7 +52,7 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   output logic           resp_valid_o,          // Note: Consumer is assumed to be 'ready' whenever resp_valid_o = 1
   output obi_data_resp_t resp_o,
 
-  output logic           integrity_err_o,
+  output logic           alert_major_o,
 
   input xsecure_ctrl_t   xsecure_ctrl_i,
 
@@ -68,6 +68,8 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
   logic       rchk_err_resp;
 
   logic       integrity_resp;
+
+  logic       protocol_err;                 // Set if rvalid arrives when no outstanding transactions are active
 
 
   //////////////////////////////////////////////////////////////////////////////
@@ -153,6 +155,8 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
       .integrity_resp_o   (integrity_resp     ),
       .rchk_err_resp_o    (rchk_err_resp      ),
 
+      .protocol_err_o     (protocol_err       ),
+
       // OBI interface
       .obi_req_i          (m_c_obi_data_if.s_req.req       ),
       .obi_gnt_i          (m_c_obi_data_if.s_gnt.gnt       ),
@@ -161,9 +165,9 @@ module cv32e40s_data_obi_interface import cv32e40s_pkg::*;
     );
 
   // Checking rvalid parity
-  // integrity_err_o will go high immediately
+  // alert_major_o will go high immediately
   assign rvalidpar_err_resp = (m_c_obi_data_if.s_rvalid.rvalid == m_c_obi_data_if.s_rvalid.rvalidpar);
 
-  assign integrity_err_o = rchk_err_resp || rvalidpar_err_resp || gntpar_err;
+  assign alert_major_o = rchk_err_resp || rvalidpar_err_resp || gntpar_err || protocol_err;
 
 endmodule

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -109,7 +109,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   input xsecure_ctrl_t  xsecure_ctrl_i,
   output  logic         lfsr_shift_o,
 
-  output  logic         alert_major_o,
+  output  logic         integrity_err_o,
+  output  logic         protocol_err_o,
 
   // eXtension interface
   if_xif.cpu_compressed xif_compressed_if,      // XIF compressed interface
@@ -178,9 +179,11 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   logic              id_ready_no_dummy; // Ready signal to acknowledge the sequencer
 
-  logic              first_op;        // Local first_op, including dummies
+  logic              first_op;          // Local first_op, including dummies
 
-  logic              alert_major_obi; // Integrity error or protocol error from OBI interface
+  logic              integrity_err_obi; // Integrity error from OBI interface
+  logic              protocol_err_obi;  // Protocol error from OBI interface
+
   logic              unused_signals;
 
   // Fetch address selection
@@ -325,7 +328,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .resp_valid_o         ( bus_resp_valid   ),
     .resp_o               ( bus_resp         ),
 
-    .alert_major_o        ( alert_major_obi  ),   // immediate integrity error or protocol error
+    .integrity_err_o      ( integrity_err_obi),   // immediate integrity error
+    .protocol_err_o       ( protocol_err_obi ),   // immediate protocol error
 
     .xsecure_ctrl_i       ( xsecure_ctrl_i   ),
     .m_c_obi_instr_if     ( m_c_obi_instr_if )
@@ -636,8 +640,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     end
   endgenerate
 
-  // Set alert output
-  assign alert_major_o = alert_major_obi;
+  // Set error outputs
+  assign integrity_err_o = integrity_err_obi;
+  assign protocol_err_o  = protocol_err_obi;
 
   // Some signals are unused on purpose. Use them here for easier LINT waiving.
   assign unused_signals = |prefetch_outstnd_cnt_q;

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -109,7 +109,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   input xsecure_ctrl_t  xsecure_ctrl_i,
   output  logic         lfsr_shift_o,
 
-  output  logic         integrity_err_o,
+  output  logic         alert_major_o,
 
   // eXtension interface
   if_xif.cpu_compressed xif_compressed_if,      // XIF compressed interface
@@ -180,7 +180,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   logic              first_op;        // Local first_op, including dummies
 
-  logic              integrity_err_obi; // Integrity error from OBI interface
+  logic              alert_major_obi; // Integrity error or protocol error from OBI interface
   logic              unused_signals;
 
   // Fetch address selection
@@ -325,7 +325,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .resp_valid_o         ( bus_resp_valid   ),
     .resp_o               ( bus_resp         ),
 
-    .integrity_err_o      ( integrity_err_obi),   // immediate integrity error, either parity or chk
+    .alert_major_o        ( alert_major_obi  ),   // immediate integrity error or protocol error
 
     .xsecure_ctrl_i       ( xsecure_ctrl_i   ),
     .m_c_obi_instr_if     ( m_c_obi_instr_if )
@@ -636,8 +636,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     end
   endgenerate
 
-  // Set integrity error output
-  assign integrity_err_o = integrity_err_obi;
+  // Set alert output
+  assign alert_major_o = alert_major_obi;
 
   // Some signals are unused on purpose. Use them here for easier LINT waiving.
   assign unused_signals = |prefetch_outstnd_cnt_q;

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -183,6 +183,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   logic              integrity_err_obi; // Integrity error from OBI interface
   logic              protocol_err_obi;  // Protocol error from OBI interface
+  logic              prefetch_protocol_err;
 
   logic              unused_signals;
 
@@ -254,7 +255,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     // Prefetch Buffer Status
     .prefetch_busy_o          ( prefetch_busy               ),
     .one_txn_pend_n           ( prefetch_one_txn_pend_n     ),
-    .outstnd_cnt_q_o          ( prefetch_outstnd_cnt_q      )
+    .outstnd_cnt_q_o          ( prefetch_outstnd_cnt_q      ),
+
+    .protocol_err_o           ( prefetch_protocol_err       )
   );
 
   //////////////////////////////////////////////////////////////////////////////
@@ -642,7 +645,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   // Set error outputs
   assign integrity_err_o = integrity_err_obi;
-  assign protocol_err_o  = protocol_err_obi;
+  assign protocol_err_o  = protocol_err_obi || prefetch_protocol_err;
 
   // Some signals are unused on purpose. Use them here for easier LINT waiving.
   assign unused_signals = |prefetch_outstnd_cnt_q;

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -51,7 +51,8 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   output logic           resp_valid_o,          // Note: Consumer is assumed to be 'ready' whenever resp_valid_o = 1
   output obi_inst_resp_t resp_o,
 
-  output logic           alert_major_o,         // integrity or protocol error
+  output logic           integrity_err_o,       // integrity error
+  output logic           protocol_err_o,        // protocol error
 
   input xsecure_ctrl_t   xsecure_ctrl_i,
 
@@ -249,7 +250,8 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
   // rchk_err: recomputed checksum mismatch when rvalid=1 and PMA has integrity set for the transaction
   // rvalidpar_err_resp: mismatch on rvalid parity bit at any time
   // gntpar_err: mismatch on gnt parity bit at any time
-  assign alert_major_o = rchk_err_resp || rvalidpar_err_resp || gntpar_err || protocol_err;
+  assign integrity_err_o = rchk_err_resp || rvalidpar_err_resp || gntpar_err;
+  assign protocol_err_o  = protocol_err;
 
 
 

--- a/rtl/cv32e40s_load_store_unit.sv
+++ b/rtl/cv32e40s_load_store_unit.sv
@@ -76,8 +76,9 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   output logic        valid_1_o,
   input  logic        ready_1_i,
 
-  // Major alert triggers from LSU (integrity and protocol hardening)
-  output logic        alert_major_o,
+  // Integrity and protocol error flags
+  output logic        integrity_err_o,
+  output logic        protocol_err_o,
 
   input xsecure_ctrl_t   xsecure_ctrl_i,
 
@@ -156,7 +157,8 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   logic           trans_valid_q;        // trans_valid got clocked without trans_ready
 
   logic           protocol_err_mpu;     // Set when MPU gives a response when no outstanding transactions are active
-  logic           alert_major_obi;      // Major alert from OBI interface (integrity or protocol errors)
+  logic           integrity_err_obi;    // OBI interface integrity error
+  logic           protocol_err_obi;    // OBI interface protocol error
 
   logic                  xif_req;       // The ongoing memory request comes from the XIF interface
   logic                  xif_mpu_err;   // The ongoing memory request caused an MPU error
@@ -732,14 +734,16 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
     .resp_valid_o       ( bus_resp_valid    ),
     .resp_o             ( bus_resp          ),
 
-    .alert_major_o      ( alert_major_obi   ),
+    .integrity_err_o    ( integrity_err_obi ),
+    .protocol_err_o     ( protocol_err_obi  ),
 
     .xsecure_ctrl_i     ( xsecure_ctrl_i    ),
     .m_c_obi_data_if    ( m_c_obi_data_if   )
   );
 
-  // Integrity error and protocol hardening fans into alert major
-  assign alert_major_o = alert_major_obi || protocol_err_mpu;
+  // Set error bits (fans into alert_major)
+  assign integrity_err_o = integrity_err_obi;
+  assign protocol_err_o  = protocol_err_obi || protocol_err_mpu;
 
   //////////////////////////////////////////////////////////////////////////////
   // XIF interface response and result data

--- a/rtl/cv32e40s_load_store_unit.sv
+++ b/rtl/cv32e40s_load_store_unit.sv
@@ -157,6 +157,7 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
   logic           trans_valid_q;        // trans_valid got clocked without trans_ready
 
   logic           protocol_err_mpu;     // Set when MPU gives a response when no outstanding transactions are active
+  logic           filter_protocol_err;  // Protocol error in response filter
   logic           integrity_err_obi;    // OBI interface integrity error
   logic           protocol_err_obi;    // OBI interface protocol error
 
@@ -671,22 +672,24 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
     .OUTSTND_CNT_WIDTH  ( OUTSTND_CNT_WIDTH  )
   )
     response_filter_i
-      (.clk          ( clk                ),
-       .rst_n        ( rst_n              ),
-       .busy_o       ( filter_resp_busy   ),
+      (.clk            ( clk                 ),
+       .rst_n          ( rst_n               ),
+       .busy_o         ( filter_resp_busy    ),
 
-       .valid_i      ( filter_trans_valid ),
-       .ready_o      ( filter_trans_ready ),
-       .trans_i      ( filter_trans       ),
-       .resp_valid_o ( filter_resp_valid  ),
-       .resp_o       ( filter_resp        ),
-       .err_o        ( filter_err         ),
+       .valid_i        ( filter_trans_valid  ),
+       .ready_o        ( filter_trans_ready  ),
+       .trans_i        ( filter_trans        ),
+       .resp_valid_o   ( filter_resp_valid   ),
+       .resp_o         ( filter_resp         ),
+       .err_o          ( filter_err          ),
 
-       .valid_o      ( buffer_trans_valid ),
-       .ready_i      ( buffer_trans_ready ),
-       .trans_o      ( buffer_trans       ),
-       .resp_valid_i ( bus_resp_valid     ),
-       .resp_i       ( bus_resp           )
+       .valid_o        ( buffer_trans_valid  ),
+       .ready_i        ( buffer_trans_ready  ),
+       .trans_o        ( buffer_trans        ),
+       .resp_valid_i   ( bus_resp_valid      ),
+       .resp_i         ( bus_resp            ),
+
+       .protocol_err_o ( filter_protocol_err )
 
      );
 
@@ -743,7 +746,7 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
 
   // Set error bits (fans into alert_major)
   assign integrity_err_o = integrity_err_obi;
-  assign protocol_err_o  = protocol_err_obi || protocol_err_mpu;
+  assign protocol_err_o  = protocol_err_obi || protocol_err_mpu || filter_protocol_err;
 
   //////////////////////////////////////////////////////////////////////////////
   // XIF interface response and result data

--- a/rtl/cv32e40s_lsu_response_filter.sv
+++ b/rtl/cv32e40s_lsu_response_filter.sv
@@ -58,6 +58,8 @@ module cv32e40s_lsu_response_filter
    output logic           resp_valid_o,
    output obi_data_resp_t resp_o, // Todo: This also carries the obi error field. Could replace by data_resp_t
 
+   output logic           protocol_err_o,
+
 
    // Todo: This error signal could be merged with mpu_status_e, and be signaled via the resp_o above (if replaced by data_resp_t).
    //       This would make the error flow all the way through the MPU and not bypass the MPU as it does now.
@@ -180,5 +182,8 @@ module cv32e40s_lsu_response_filter
 
   // bus_resp goes straight through
   assign resp_o = resp_i;
+
+  // Raise protocol error when we get rvalid with outstanding count == 0 for either core or bus side
+  assign protocol_err_o = (resp_valid_o && !(|core_cnt_q)) || (resp_valid_i && !(|bus_cnt_q));
 
 endmodule

--- a/rtl/cv32e40s_obi_integrity_fifo.sv
+++ b/rtl/cv32e40s_obi_integrity_fifo.sv
@@ -53,6 +53,9 @@ module cv32e40s_obi_integrity_fifo import cv32e40s_pkg::*;
   output logic                        integrity_resp_o,
   output logic                        rchk_err_resp_o,
 
+  // Protocol hardening error output
+  output logic                        protocol_err_o,
+
   // OBI handshake signals
   input  logic                        obi_req_i,
   input  logic                        obi_gnt_i,
@@ -184,6 +187,7 @@ module cv32e40s_obi_integrity_fifo import cv32e40s_pkg::*;
     .err_o    (rchk_err_resp_o)
   );
 
+  assign protocol_err_o = obi_rvalid_i && !(|cnt_q);
 
 
  endmodule

--- a/rtl/cv32e40s_prefetch_unit.sv
+++ b/rtl/cv32e40s_prefetch_unit.sv
@@ -64,7 +64,9 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
   input xsecure_ctrl_t  xsecure_ctrl_i,
 
   // Prefetch Buffer Status
-  output logic        prefetch_busy_o
+  output logic        prefetch_busy_o,
+
+  output logic        protocol_err_o
 );
 
   logic fetch_valid;
@@ -141,7 +143,9 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
     .instr_addr_o          ( prefetch_addr_o         ),
     .instr_priv_lvl_o      ( prefetch_priv_lvl_o     ),
     .instr_is_clic_ptr_o   ( prefetch_is_clic_ptr_o  ),
-    .instr_is_tbljmp_ptr_o ( prefetch_is_tbljmp_ptr_o)
+    .instr_is_tbljmp_ptr_o ( prefetch_is_tbljmp_ptr_o),
+
+    .protocol_err_o        ( protocol_err_o          )
 
   );
 

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -120,6 +120,7 @@ module cv32e40s_core_sva
   input logic        pc_err_if,
   input logic        csr_err,
   input logic        itf_int_err,
+  input logic        itf_prot_err,
   input logic        rf_ecc_err,
 
   input logic        sys_mret_unqual_id_bypass,
@@ -536,6 +537,11 @@ end
     assert property (@(posedge clk) disable iff (!rst_ni)
                     1'b1 |-> !itf_int_err)
           else `uvm_error("core", "itf_int_err shall be zero.")
+
+  a_no_prot_err:
+  assert property (@(posedge clk) disable iff (!rst_ni)
+                  1'b1 |-> !itf_prot_err)
+        else `uvm_error("core", "itf_prot_err shall be zero.")
 
   a_no_pc_err:
     assert property (@(posedge clk) disable iff (!rst_ni)


### PR DESCRIPTION
Added OBI protocol hardening. A major alert will be flagged if any OBI interface receive an _rvalid when the outstanding counter is zero. A similar check is performed in the LSU on the inside of the MPU, also resulting in alert_major if the MPU sends a valid response when the outstanding counter int he LSU is zero.

Not SEC clean as this fans into changes in alert_major_o.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>