### PR TITLE
Fix for issue #293. 

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -195,6 +195,8 @@ module cv32e40s_wrapper
         core_i.if_stage_i.gen_dummy_instr.dummy_instr_i cv32e40s_dummy_instr_sva
       dummy_instr_sva
     (
+      .if_valid_i ( core_i.if_valid ),
+      .id_ready_i ( core_i.id_ready ),
       .*
     );
     end

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -83,9 +83,9 @@ module cv32e40s_dummy_instr
 
   assign dummy_insert_o = (cnt_q > lfsr_cnt) && dummy_en;
 
-  assign cnt_rst        = !dummy_en      ||      // Reset counter when dummy instructions are disabled
-                          dummy_insert_o ||      // Reset counter when inserting dummy instruction
-                          xsecure_ctrl_i.cntrst; // Reset counter when requested by xsecure_ctrl (due to csr updates)
+  assign cnt_rst        = !dummy_en                          ||      // Reset counter when dummy instructions are disabled
+                          (dummy_insert_o && instr_issued_i) ||      // Reset counter when inserting dummy instruction which is propagated to the ID stage
+                          xsecure_ctrl_i.cntrst;                     // Reset counter when requested by xsecure_ctrl (due to csr updates)
 
   assign cnt_next       = cnt_rst        ? '0           : // Reset counter
                           instr_issued_i ? cnt_q + 1'b1 : // Count issued instructions only


### PR DESCRIPTION
A dummy instruction which is not yet accepted by the id_stage shall not reset the counter that tracks number of issued instructions.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>