### PR TITLE
Random replacement for HINT instructions

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -66,7 +66,10 @@ module cv32e40s_wrapper
   parameter int          SMCLIC_ID_WIDTH              = 5,
   parameter int          DBG_NUM_TRIGGERS             = 1,
   parameter int          PMA_NUM_REGIONS              = 0,
-  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
+  parameter lfsr_cfg_t   LFSR0_CFG                    = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
+  parameter lfsr_cfg_t   LFSR1_CFG                    = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
+  parameter lfsr_cfg_t   LFSR2_CFG                    = LFSR_CFG_DEFAULT  // Do not use default value for LFSR configuration
 )
 (
   // Clock and Reset
@@ -195,8 +198,9 @@ module cv32e40s_wrapper
         core_i.if_stage_i.gen_dummy_instr.dummy_instr_i cv32e40s_dummy_instr_sva
       dummy_instr_sva
     (
-      .if_valid_i ( core_i.if_valid ),
-      .id_ready_i ( core_i.id_ready ),
+      .if_valid_i ( core_i.if_valid                   ),
+      .id_ready_i ( core_i.id_ready                   ),
+      .hint_id_i  ( core_i.if_id_pipe.instr_meta.hint ),
       .*
     );
     end
@@ -514,6 +518,7 @@ endgenerate
          .operand_a_fw_id_i        ( core_i.id_stage_i.operand_a_fw                                       ),
          .operand_b_fw_id_i        ( core_i.id_stage_i.operand_b_fw                                       ),
          .first_op_id_i            ( core_i.id_stage_i.first_op                                           ),
+         .hint_id_i                ( core_i.id_stage_i.if_id_pipe_i.instr_meta.hint                       ),
 
          // EX Probes
          .ex_ready_i               ( core_i.ex_stage_i.ex_ready_o                                         ),
@@ -547,6 +552,7 @@ endgenerate
          .is_dummy_instr_wb_i      ( core_i.wb_stage_i.ex_wb_pipe_i.instr_meta.dummy                      ),
          .abort_op_wb_i            ( core_i.wb_stage_i.abort_op_o                                         ),
          .clic_ptr_wb_i            ( core_i.wb_stage_i.ex_wb_pipe_i.instr_meta.clic_ptr                   ),
+         .hint_wb_i                ( core_i.id_stage_i.ex_wb_pipe_i.instr_meta.hint                       ),
 
          .branch_addr_n_i          ( core_i.if_stage_i.branch_addr_n                                      ),
 
@@ -747,7 +753,10 @@ endgenerate
           .SMCLIC_ID_WIDTH       ( SMCLIC_ID_WIDTH       ),
           .DBG_NUM_TRIGGERS      ( DBG_NUM_TRIGGERS      ),
           .PMA_NUM_REGIONS       ( PMA_NUM_REGIONS       ),
-          .PMA_CFG               ( PMA_CFG               ))
+          .PMA_CFG               ( PMA_CFG               ),
+          .LFSR0_CFG             ( LFSR0_CFG             ),
+          .LFSR1_CFG             ( LFSR1_CFG             ),
+          .LFSR2_CFG             ( LFSR2_CFG             ))
     core_i (.*);
 
 endmodule

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -303,8 +303,8 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
       end
     end
 
-    if (if_id_pipe_i.instr_meta.dummy) begin
-      // Overriding operands with data from LFSRs for dummy instructions, except for reads from R0
+    if (if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) begin
+      // Overriding operands with data from LFSRs for dummy and hint instructions, except for reads from R0
       if (rf_raddr_id_i[0] != '0) begin
         ctrl_byp_o.operand_a_fw_mux_sel = SEL_LFSR;
       end

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -1213,7 +1213,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
       // Note that this event bit is further gated before sent to the actual counters in case
       // other conditions prevent counting.
       // CLIC: Exluding pointer fetches as they are not instructions
-      if (ex_valid_i && wb_ready_i && last_op_ex_i && !ex_wb_pipe_i.instr_meta.clic_ptr) begin
+      if (ex_valid_i && wb_ready_i && last_op_ex_i && !id_ex_pipe_i.instr_meta.clic_ptr) begin
         wb_counter_event <= 1'b1;
       end else begin
         // Keep event flag high while WB is halted, as we don't know if it will retire yet

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -1208,9 +1208,10 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .clk                ( clk         ),
     .rst_n              ( rst_ni      ),
 
-
-   .dummy_instr_id_i   ( if_id_pipe.instr_meta.dummy ),
-   .dummy_instr_wb_i   ( ex_wb_pipe.instr_meta.dummy ),
+    .hint_instr_id_i    ( if_id_pipe.instr_meta.hint),
+    .hint_instr_wb_i    ( ex_wb_pipe.instr_meta.hint),
+    .dummy_instr_id_i   ( if_id_pipe.instr_meta.dummy ),
+    .dummy_instr_wb_i   ( ex_wb_pipe.instr_meta.dummy ),
 
     // ECC error output
     .ecc_err_o          ( rf_ecc_err         ),

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -386,6 +386,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   logic                         dscratch1_rd_error;                             // Not used
   logic                         mcause_rd_error;                                // Not used
 
+
   // Local instr_valid for write portion (WB)
   // Not factoring in ctrl_fsm_i.halt_limited_wb. This signal is only set during SLEEP mode, and while in SLEEP
   // there cannot be any CSR instruction in WB.
@@ -1981,6 +1982,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     if (SECURE) begin : xsecure
 
       logic [2:0] lfsr_lockup;
+      logic       lfsr_en;
 
       cv32e40s_csr
       #(
@@ -2001,6 +2003,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rd_error_o     ( cpuctrl_rd_error      )
       );
 
+      assign lfsr_en = cpuctrl_q.rnddummy || cpuctrl_q.rndhint;
+
       // Shifting LFSR0 in IF because it controls instruction insertion
       cv32e40s_lfsr
       #(
@@ -2012,7 +2016,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rst_n          ( rst_n                 ),
         .seed_i         ( csr_wdata_int         ),      // Direct use of csr_wdata_int (secureseed0_n = 0 used by RVFI; resolution on read)
         .seed_we_i      ( secureseed0_we        ),
-        .enable_i       ( cpuctrl_q.rnddummy    ),
+        .enable_i       ( lfsr_en               ),
         .shift_i        ( lfsr_shift_if_i       ),
         .data_o         ( xsecure_ctrl_o.lfsr0  ),
         .lockup_o       ( lfsr_lockup[0]        )
@@ -2029,7 +2033,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rst_n          ( rst_n                 ),
         .seed_i         ( csr_wdata_int         ),      // Direct use of csr_wdata_int (secureseed1_n = 0 used by RVFI; resolution on read)
         .seed_we_i      ( secureseed1_we        ),
-        .enable_i       ( cpuctrl_q.rnddummy    ),
+        .enable_i       ( lfsr_en               ),
         .shift_i        ( lfsr_shift_id_i       ),
         .data_o         ( xsecure_ctrl_o.lfsr1  ),
         .lockup_o       ( lfsr_lockup[1]        )
@@ -2045,7 +2049,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rst_n          ( rst_n                 ),
         .seed_i         ( csr_wdata_int         ),      // Direct use of csr_wdata_int (secureseed2_n = 0 used by RVFI; resolution on read)
         .seed_we_i      ( secureseed2_we        ),
-        .enable_i       ( cpuctrl_q.rnddummy    ),
+        .enable_i       ( lfsr_en               ),
         .shift_i        ( lfsr_shift_id_i       ),
         .data_o         ( xsecure_ctrl_o.lfsr2  ),
         .lockup_o       ( lfsr_lockup[2]        )
@@ -2058,7 +2062,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       assign lfsr_lockup_o = |lfsr_lockup;
 
       // Reset dummy instruction counter when writing registers that affect insertion frequency
-      assign xsecure_ctrl_o.cntrst = cpuctrl_we || secureseed0_we || lfsr_lockup[0];
+      // A pipeline flush will also be performed.
+      assign xsecure_ctrl_o.cntrst = cpuctrl_we || secureseed0_we;
 
     end // block: xsecure
     else begin : no_xsecure

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -81,6 +81,11 @@ module cv32e40s_dummy_instr
 
   assign dummy_en   = ctrl_fsm_i.allow_dummy_instr && xsecure_ctrl_i.cpuctrl.rnddummy;
 
+  // Hint instructions will consume one random instruction and perform an lfsr shift.
+  // lfsr_cnt will update when the dummy or hint instruction leaves the ID stage
+  // cnt_q is updated every time an instruction goes from IF to ID
+  //   - reset when a dummy goes from IF to ID
+  //   - incremented when any other instruction (including hint) goes from ID to ID
   assign dummy_insert_o = (cnt_q > lfsr_cnt) && dummy_en;
 
   assign cnt_rst        = !dummy_en                          ||      // Reset counter when dummy instructions are disabled
@@ -127,7 +132,11 @@ module cv32e40s_dummy_instr
   end
 
   assign rd  =  5'h0; // Ignoring result by writing it to x0
-  assign imm = 12'h0; // Offset is 0 because PC of the dummy instruction is the same as the target instruction.
+  // When inserting a dummy, use offset=0 because PC of the dummy instruction is the same as the target instruction.
+  // When not inserting a dummy, the random instruction may be used for a HINT instruction which much branch to
+  // the next instruction (PC+2 since the HINT is a compressed c.slli)
+  assign imm = dummy_insert_o ? 12'h0 : 12'h2;
+
 
   assign instr[31:25] = (opcode == OPCODE_BRANCH) ? {imm[12], imm[10:5]} : funct7;
   assign instr[24:20] = lfsr_rs2;

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -133,7 +133,7 @@ module cv32e40s_dummy_instr
 
   assign rd  =  5'h0; // Ignoring result by writing it to x0
   // When inserting a dummy, use offset=0 because PC of the dummy instruction is the same as the target instruction.
-  // When not inserting a dummy, the random instruction may be used for a HINT instruction which much branch to
+  // When not inserting a dummy, the random instruction may be used for a HINT instruction which must branch to
   // the next instruction (PC+2 since the HINT is a compressed c.slli)
   assign imm = dummy_insert_o ? 12'h0 : 12'h2;
 

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -230,7 +230,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
 
   // Ensures one shift of the operand LFSRs for each dummy instruction in ID
-  assign lfsr_shift_o    = (id_valid_o && ex_ready_i) && if_id_pipe_i.instr_meta.dummy && last_sec_op;
+  assign lfsr_shift_o    = (id_valid_o && ex_ready_i) && (if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) && last_sec_op;
 
   assign instr = if_id_pipe_i.instr.bus_resp.rdata;
   assign c_instr = if_id_pipe_i.compressed_instr;

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -229,7 +229,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
 
 
-  // Ensures one shift of the operand LFSRs for each dummy instruction in ID
+  // Ensures one shift of the operand LFSRs for each dummy or hint instruction in ID
   assign lfsr_shift_o    = (id_valid_o && ex_ready_i) && (if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) && last_sec_op;
 
   assign instr = if_id_pipe_i.instr.bus_resp.rdata;

--- a/rtl/cv32e40s_register_file.sv
+++ b/rtl/cv32e40s_register_file.sv
@@ -35,6 +35,8 @@ module cv32e40s_register_file import cv32e40s_pkg::*;
     input logic                           clk,
     input logic                           rst_n,
 
+    input logic                           hint_instr_id_i,
+    input logic                           hint_instr_wb_i,
     input logic                           dummy_instr_id_i,
     input logic                           dummy_instr_wb_i,
 
@@ -63,7 +65,7 @@ module cv32e40s_register_file import cv32e40s_pkg::*;
   //-----------------------------------------------------------------------------
   generate
     if (SECURE) begin
-      assign mem_gated[0] = dummy_instr_id_i ? mem[0] : RF_REG_RV;
+      assign mem_gated[0] = (dummy_instr_id_i || hint_instr_id_i) ? mem[0] : RF_REG_RV;
       for (genvar addr=1; addr < REGFILE_NUM_WORDS; addr++) begin
         assign mem_gated[addr] = mem[addr];
       end
@@ -104,7 +106,7 @@ module cv32e40s_register_file import cv32e40s_pkg::*;
         if(~rst_n) begin
           mem[0] <= RF_REG_RV;
         end else begin
-          if (dummy_instr_wb_i) begin
+          if (dummy_instr_wb_i || hint_instr_wb_i) begin
             for(int j=0; j<REGFILE_NUM_WRITE_PORTS; j++) begin : dummy_rf_write_ports
               if(we_dec[j][0] == 1'b1) begin
                 mem[0] <= wdata_i[j];

--- a/rtl/cv32e40s_register_file_wrapper.sv
+++ b/rtl/cv32e40s_register_file_wrapper.sv
@@ -38,9 +38,11 @@ module cv32e40s_register_file_wrapper import cv32e40s_pkg::*;
    input logic      clk,
    input logic      rst_n,
 
-   // R0 Dummy instruction handling
-    input logic     dummy_instr_id_i,
-    input logic     dummy_instr_wb_i,
+   // R0 Dummy and hint instruction handling
+   input logic     hint_instr_id_i,
+   input logic     hint_instr_wb_i,
+   input logic     dummy_instr_id_i,
+   input logic     dummy_instr_wb_i,
 
    // ECC
    output logic     ecc_err_o,
@@ -68,6 +70,8 @@ module cv32e40s_register_file_wrapper import cv32e40s_pkg::*;
        .clk                ( clk                ),
        .rst_n              ( rst_n              ),
 
+       .hint_instr_id_i    ( hint_instr_id_i    ),
+       .hint_instr_wb_i    ( hint_instr_wb_i    ),
        .dummy_instr_id_i   ( dummy_instr_id_i   ),
        .dummy_instr_wb_i   ( dummy_instr_wb_i   ),
 

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1191,6 +1191,7 @@ typedef struct packed {
 typedef struct packed
 {
   logic        dummy;
+  logic        hint;
   logic        compressed;
   logic        clic_ptr;
   logic        tbljmp;

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -146,38 +146,38 @@ module cv32e40s_id_stage_sva
       else `uvm_error("id_stage", "Trigger match on dummy instruction")
 
 
-  // Assert that regular (non-dummy) instructions use 0 instead of the R0 register value
-  a_non_dummy_reads_0_from_r0_p0:
+  // Assert that regular (non-dummy, non-hint) instructions use 0 instead of the R0 register value
+  a_non_dummy_or_hint_reads_0_from_r0_p0:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && !if_id_pipe_i.instr_meta.dummy |-> (operand_a_fw == 32'h0))
-      else `uvm_error("id_stage", "Non-dummy instruction used non-zero value from R0 (on read port 0)")
+                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && !(if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) |-> (operand_a_fw == 32'h0))
+      else `uvm_error("id_stage", "Non-dummy or non-hint instruction used non-zero value from R0 (on read port 0)")
 
-  a_non_dummy_reads_0_from_r0_p1:
+  a_non_dummy_or_hint_reads_0_from_r0_p1:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && !if_id_pipe_i.instr_meta.dummy |-> (operand_b_fw == 32'h0))
-      else `uvm_error("id_stage", "Non-dummy instruction used non-zero value from R0 (on read port 1)")
+                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && !(if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) |-> (operand_b_fw == 32'h0))
+      else `uvm_error("id_stage", "Non-dummy or non-hint instruction used non-zero value from R0 (on read port 1)")
 
-  a_dummy_can_read_r0_p0:
+  a_dummy_or_hint_can_read_r0_p0:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && if_id_pipe_i.instr_meta.dummy |-> (operand_a_fw == rf_rdata_i[0]))
-      else `uvm_error("id_stage", "Dummy instruction could not read from R0 (on read port 0)")
+                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && (if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) |-> (operand_a_fw == rf_rdata_i[0]))
+      else `uvm_error("id_stage", "Dummy or hint instruction could not read from R0 (on read port 0)")
 
-  a_dummy_can_read_r0_p1:
+  a_dummy_or_hint_can_read_r0_p1:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && if_id_pipe_i.instr_meta.dummy |-> (operand_b_fw == rf_rdata_i[1]))
-      else `uvm_error("id_stage", "Dummy instruction could not read from R0 (on read port 1)")
+                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && (if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) |-> (operand_b_fw == rf_rdata_i[1]))
+      else `uvm_error("id_stage", "Dummy or hint instruction could not read from R0 (on read port 1)")
 
-  a_dummy_opa_mux_check:
+  a_dummy_or_hint_opa_mux_check:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     if_id_pipe_i.instr_meta.dummy |-> ( (ctrl_byp_i.operand_a_fw_mux_sel == SEL_LFSR) ||
-                                                        ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[0] == 0))))
-      else `uvm_error("id_stage", "Illegal operand a mux select value for dummy instruction")
+                     (if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) |-> ( (ctrl_byp_i.operand_a_fw_mux_sel == SEL_LFSR) ||
+                                                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[0] == 0))))
+      else `uvm_error("id_stage", "Illegal operand a mux select value for dummy or hint instruction")
 
-  a_dummy_opb_mux_check:
+  a_dummy_or_hint_opb_mux_check:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     if_id_pipe_i.instr_meta.dummy |-> ( (ctrl_byp_i.operand_b_fw_mux_sel == SEL_LFSR) ||
-                                                        ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[1] == 0))))
-      else `uvm_error("id_stage", "Illegal operand b mux select value for dummy instruction")
+                     (if_id_pipe_i.instr_meta.dummy || if_id_pipe_i.instr_meta.hint) |-> ( (ctrl_byp_i.operand_b_fw_mux_sel == SEL_LFSR) ||
+                                                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[1] == 0))))
+      else `uvm_error("id_stage", "Illegal operand b mux select value for dummy or hint instruction")
 
 
   // Ensure that functional unit enables are one-hot (ALU and DIV both use the ALU though)

--- a/sva/cv32e40s_if_stage_sva.sv
+++ b/sva/cv32e40s_if_stage_sva.sv
@@ -29,6 +29,7 @@ module cv32e40s_if_stage_sva
 
   input logic           if_ready,
   input logic           if_valid_o,
+  input logic           id_ready_i,
   input logic [31:0]    pc_if_o,
   input logic           prefetch_resp_valid,
   input ctrl_fsm_t      ctrl_fsm_i,
@@ -105,11 +106,12 @@ module cv32e40s_if_stage_sva
       else `uvm_error("if_stage", "Prefetcher popped during dummy instruction")
 
   // Assert that we do not trigger dummy instructions multiple cycles in a row
+  // Dummies may have to wait for id_ready, or even if_valid in case of halting IF.
   // Todo: When/if we use allow_dummy_instr from controller_fsm to guarantee progress,
   //       this assertion should be updated to check for guaranteed progress
   a_no_back_to_back_dummy_instructions :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     dummy_insert |-> !$past(dummy_insert))
+                     dummy_insert |-> !$past(dummy_insert && if_valid_o && id_ready_i))
       else `uvm_error("if_stage", "Two dummy instructions in a row")
 
   // Assert that we do not trigger dummy instructions when the sequencer is in the middle of a sequence


### PR DESCRIPTION
Implemented random replacement for HINT instruction (c.slli with rd==x0 and immediate != 0).

Replacement instruction is taken from the random instruction generation within the dummy module. Hints are replaced by add/and/mul/bltu, but will show up on RVFI as c.slli.

Removed lfsr_lockup[0] as a cause of counter reset for the dummy module, as this could violate the dummy frequency.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>