### PR TITLE
Dummy instruction fixes

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -66,7 +66,10 @@ module cv32e40s_wrapper
   parameter int          SMCLIC_ID_WIDTH              = 5,
   parameter int          DBG_NUM_TRIGGERS             = 1,
   parameter int          PMA_NUM_REGIONS              = 0,
-  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
+  parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
+  parameter lfsr_cfg_t   LFSR0_CFG                    = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
+  parameter lfsr_cfg_t   LFSR1_CFG                    = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
+  parameter lfsr_cfg_t   LFSR2_CFG                    = LFSR_CFG_DEFAULT  // Do not use default value for LFSR configuration
 )
 (
   // Clock and Reset
@@ -312,7 +315,8 @@ module cv32e40s_wrapper
   bind cv32e40s_core:
     core_i cv32e40s_core_sva
       #(.PMA_NUM_REGIONS(PMA_NUM_REGIONS),
-        .SMCLIC(SMCLIC))
+        .SMCLIC(SMCLIC),
+        .REGFILE_NUM_READ_PORTS(core_i.REGFILE_NUM_READ_PORTS))
       core_sva (// probed cs_registers signals
                 .cs_registers_mie_q               (core_i.cs_registers_i.mie_q),
                 .cs_registers_mepc_n              (core_i.cs_registers_i.mepc_n),
@@ -747,7 +751,10 @@ endgenerate
           .SMCLIC_ID_WIDTH       ( SMCLIC_ID_WIDTH       ),
           .DBG_NUM_TRIGGERS      ( DBG_NUM_TRIGGERS      ),
           .PMA_NUM_REGIONS       ( PMA_NUM_REGIONS       ),
-          .PMA_CFG               ( PMA_CFG               ))
+          .PMA_CFG               ( PMA_CFG               ),
+          .LFSR0_CFG             ( LFSR0_CFG             ),
+          .LFSR1_CFG             ( LFSR1_CFG             ),
+          .LFSR2_CFG             ( LFSR2_CFG             ))
     core_i (.*);
 
 endmodule

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -96,9 +96,9 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   logic                              tbljmp_unqual_id;          // Table jump in ID (not qualified with alu_en)
 
   // Dummy or hint instructions in stages
-  logic                              dummy_id;
-  logic                              dummy_ex;
-  logic                              dummy_wb;
+  logic                              dummy_hint_id;
+  logic                              dummy_hint_ex;
+  logic                              dummy_hint_wb;
 
 
 
@@ -130,9 +130,9 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
 
   assign csr_unqual_id = csr_exp_unqual_id || sys_mret_unqual_id || sys_wfi_unqual_id || tbljmp_unqual_id;
 
-  assign dummy_id = if_id_pipe_i.instr_valid && if_id_pipe_i.instr_meta.dummy;
-  assign dummy_ex = id_ex_pipe_i.instr_valid && id_ex_pipe_i.instr_meta.dummy;
-  assign dummy_wb = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.instr_meta.dummy;
+  assign dummy_hint_id = if_id_pipe_i.instr_valid && if_id_pipe_i.instr_meta.dummy;
+  assign dummy_hint_ex = id_ex_pipe_i.instr_valid && id_ex_pipe_i.instr_meta.dummy;
+  assign dummy_hint_wb = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.instr_meta.dummy;
 
 
   /////////////////////////////////////////////////////////////
@@ -205,18 +205,18 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   genvar i;
   generate
     for(i=0; i<REGFILE_NUM_READ_PORTS; i++) begin : gen_forward_signals
-      // For dummies x0 exist in flops, non-dummies have their writes to x0 ignored and reads as zero.
+      // For dummies/hints x0 exist in flops, non-dummies/hints have their writes to x0 ignored and reads as zero.
       // Exclude x0 from hazard detection for
-      //   - Regular non-dommy instructions
-      //   - Dummy instructions reading in ID while non-dummies are writing in EX or WB
-      // Include x0 in hazard detection for dummies which read in ID while dummies are also writing in EX or WB
-      assign rf_rd_ex_hz_en[i] = !dummy_id || (dummy_id && !dummy_ex) ? |rf_raddr_id_i[i] : 1'b1;
-      assign rf_rd_wb_hz_en[i] = !dummy_id || (dummy_id && !dummy_wb) ? |rf_raddr_id_i[i] : 1'b1;
+      //   - Regular non-dommy/hint instructions
+      //   - Dummy/hint instructions reading in ID while non-dummies/hints are writing in EX or WB
+      // Include x0 in hazard detection for dummies/hints which read in ID while dummies/hints are also writing in EX or WB
+      assign rf_rd_ex_hz_en[i] = !dummy_hint_id ? |rf_raddr_id_i[i] : |rf_raddr_id_i[i] || dummy_hint_ex;
+      assign rf_rd_wb_hz_en[i] = !dummy_hint_id ? |rf_raddr_id_i[i] : |rf_raddr_id_i[i] || dummy_hint_wb;
 
-      // Does register file read address match write address in EX (excluding R0)?
+      // Does register file read address match write address in EX (excluding R0 for regular instructions)?
       assign rf_rd_ex_match[i] = (rf_waddr_ex == rf_raddr_id_i[i]) && rf_rd_ex_hz_en[i] && rf_re_id_i[i];
 
-      // Does register file read address match write address in WB (excluding R0)?
+      // Does register file read address match write address in WB (excluding R0 for regular instructions)?
       assign rf_rd_wb_match[i] = (rf_waddr_wb == rf_raddr_id_i[i]) && rf_rd_wb_hz_en[i] && rf_re_id_i[i];
 
       // Load-read hazard (for any instruction following a load)

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -70,6 +70,8 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   logic                              rf_rd_wb_jalr_match;
   logic [REGFILE_NUM_READ_PORTS-1:0] rf_rd_ex_hz;
   logic [REGFILE_NUM_READ_PORTS-1:0] rf_rd_wb_hz;
+  logic [REGFILE_NUM_READ_PORTS-1:0] rf_rd_ex_hz_en;
+  logic [REGFILE_NUM_READ_PORTS-1:0] rf_rd_wb_hz_en;
 
   logic                              csr_write_in_ex_wb;        // Detect CSR write in EX or WB (implicit and explicit)
 
@@ -92,6 +94,13 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   logic                              jmpr_unqual_id;            // JALR in ID (not qualified with alu_en)
   logic                              sys_wfi_unqual_id;         // WFI in ID (not qualified with sys_en)
   logic                              tbljmp_unqual_id;          // Table jump in ID (not qualified with alu_en)
+
+  // Dummy or hint instructions in stages
+  logic                              dummy_id;
+  logic                              dummy_ex;
+  logic                              dummy_wb;
+
+
 
   // todo: make all qualifiers here, and use those signals later in the file
 
@@ -120,6 +129,11 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   assign tbljmp_unqual_id = if_id_pipe_i.instr_meta.tbljmp && if_id_pipe_i.instr_valid;
 
   assign csr_unqual_id = csr_exp_unqual_id || sys_mret_unqual_id || sys_wfi_unqual_id || tbljmp_unqual_id;
+
+  assign dummy_id = if_id_pipe_i.instr_valid && if_id_pipe_i.instr_meta.dummy;
+  assign dummy_ex = id_ex_pipe_i.instr_valid && id_ex_pipe_i.instr_meta.dummy;
+  assign dummy_wb = ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.instr_meta.dummy;
+
 
   /////////////////////////////////////////////////////////////
   //  ____  _        _ _    ____            _             _  //
@@ -191,11 +205,19 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   genvar i;
   generate
     for(i=0; i<REGFILE_NUM_READ_PORTS; i++) begin : gen_forward_signals
+      // For dummies x0 exist in flops, non-dummies have their writes to x0 ignored and reads as zero.
+      // Exclude x0 from hazard detection for
+      //   - Regular non-dommy instructions
+      //   - Dummy instructions reading in ID while non-dummies are writing in EX or WB
+      // Include x0 in hazard detection for dummies which read in ID while dummies are also writing in EX or WB
+      assign rf_rd_ex_hz_en[i] = !dummy_id || (dummy_id && !dummy_ex) ? |rf_raddr_id_i[i] : 1'b1;
+      assign rf_rd_wb_hz_en[i] = !dummy_id || (dummy_id && !dummy_wb) ? |rf_raddr_id_i[i] : 1'b1;
+
       // Does register file read address match write address in EX (excluding R0)?
-      assign rf_rd_ex_match[i] = (rf_waddr_ex == rf_raddr_id_i[i]) && |rf_raddr_id_i[i] && rf_re_id_i[i];
+      assign rf_rd_ex_match[i] = (rf_waddr_ex == rf_raddr_id_i[i]) && rf_rd_ex_hz_en[i] && rf_re_id_i[i];
 
       // Does register file read address match write address in WB (excluding R0)?
-      assign rf_rd_wb_match[i] = (rf_waddr_wb == rf_raddr_id_i[i]) && |rf_raddr_id_i[i] && rf_re_id_i[i];
+      assign rf_rd_wb_match[i] = (rf_waddr_wb == rf_raddr_id_i[i]) && rf_rd_wb_hz_en[i] && rf_re_id_i[i];
 
       // Load-read hazard (for any instruction following a load)
       assign rf_rd_ex_hz[i] = rf_rd_ex_match[i];

--- a/rtl/cv32e40s_register_file.sv
+++ b/rtl/cv32e40s_register_file.sv
@@ -110,8 +110,6 @@ module cv32e40s_register_file import cv32e40s_pkg::*;
                 mem[0] <= wdata_i[j];
               end
             end
-          end else begin
-            mem[0] <= RF_REG_RV;
           end
         end
       end

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -157,26 +157,34 @@ module cv32e40s_id_stage_sva
                      rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && !if_id_pipe_i.instr_meta.dummy |-> (operand_b_fw == 32'h0))
       else `uvm_error("id_stage", "Non-dummy instruction used non-zero value from R0 (on read port 1)")
 
+  // Cover to check that dummies can read non-zero values from x0
   a_dummy_can_read_r0_p0:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && if_id_pipe_i.instr_meta.dummy |-> (operand_a_fw == rf_rdata_i[0]))
+                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && if_id_pipe_i.instr_meta.dummy && (operand_a_fw != '0)|-> 1'b1)
       else `uvm_error("id_stage", "Dummy instruction could not read from R0 (on read port 0)")
 
+  // Cover to check that dummies can read non-zero values from x0
   a_dummy_can_read_r0_p1:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && if_id_pipe_i.instr_meta.dummy |-> (operand_b_fw == rf_rdata_i[1]))
+                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && if_id_pipe_i.instr_meta.dummy && (operand_b_fw != '0)|-> 1'b1)
       else `uvm_error("id_stage", "Dummy instruction could not read from R0 (on read port 1)")
 
+  // LFSR should be used for x1-bx31, regfile or relevant forwards for x0
   a_dummy_opa_mux_check:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     if_id_pipe_i.instr_meta.dummy |-> ( (ctrl_byp_i.operand_a_fw_mux_sel == SEL_LFSR) ||
-                                                        ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[0] == 0))))
+                     if_id_pipe_i.instr_meta.dummy |-> ( ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_LFSR)    && (rf_raddr_o[0] != '0))  ||
+                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[0] == 0))   ||
+                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_FW_EX)   && (rf_raddr_o[0] == 0))   ||
+                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_FW_WB)   && (rf_raddr_o[0] == 0))))
       else `uvm_error("id_stage", "Illegal operand a mux select value for dummy instruction")
 
+  // LFSR should be used for x1-bx31, regfile or relevant forwards for x0
   a_dummy_opb_mux_check:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     if_id_pipe_i.instr_meta.dummy |-> ( (ctrl_byp_i.operand_b_fw_mux_sel == SEL_LFSR) ||
-                                                        ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[1] == 0))))
+                     if_id_pipe_i.instr_meta.dummy |-> ( ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_LFSR)    && (rf_raddr_o[1] != '0))  ||
+                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[1] == 0))   ||
+                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_FW_EX)   && (rf_raddr_o[1] == 0))   ||
+                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_FW_WB)   && (rf_raddr_o[1] == 0))))
       else `uvm_error("id_stage", "Illegal operand b mux select value for dummy instruction")
 
 

--- a/sva/cv32e40s_id_stage_sva.sv
+++ b/sva/cv32e40s_id_stage_sva.sv
@@ -149,42 +149,42 @@ module cv32e40s_id_stage_sva
   // Assert that regular (non-dummy) instructions use 0 instead of the R0 register value
   a_non_dummy_reads_0_from_r0_p0:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && !if_id_pipe_i.instr_meta.dummy |-> (operand_a_fw == 32'h0))
+                     rf_re_o[0] && (rf_raddr_o[0] == 'b0) && !if_id_pipe_i.instr_meta.dummy |-> (operand_a_fw == 32'h0))
       else `uvm_error("id_stage", "Non-dummy instruction used non-zero value from R0 (on read port 0)")
 
   a_non_dummy_reads_0_from_r0_p1:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && !if_id_pipe_i.instr_meta.dummy |-> (operand_b_fw == 32'h0))
+                     rf_re_o[1] && (rf_raddr_o[1] == 'b0) && !if_id_pipe_i.instr_meta.dummy |-> (operand_b_fw == 32'h0))
       else `uvm_error("id_stage", "Non-dummy instruction used non-zero value from R0 (on read port 1)")
 
   // Cover to check that dummies can read non-zero values from x0
   a_dummy_can_read_r0_p0:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[0] && (rf_raddr_o[0] == 32'h0) && if_id_pipe_i.instr_meta.dummy && (operand_a_fw != '0)|-> 1'b1)
+                     rf_re_o[0] && (rf_raddr_o[0] == 'b0) && if_id_pipe_i.instr_meta.dummy && (operand_a_fw != '0)|-> 1'b1)
       else `uvm_error("id_stage", "Dummy instruction could not read from R0 (on read port 0)")
 
   // Cover to check that dummies can read non-zero values from x0
   a_dummy_can_read_r0_p1:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     rf_re_o[1] && (rf_raddr_o[1] == 32'h0) && if_id_pipe_i.instr_meta.dummy && (operand_b_fw != '0)|-> 1'b1)
+                     rf_re_o[1] && (rf_raddr_o[1] == 'b0) && if_id_pipe_i.instr_meta.dummy && (operand_b_fw != '0)|-> 1'b1)
       else `uvm_error("id_stage", "Dummy instruction could not read from R0 (on read port 1)")
 
   // LFSR should be used for x1-bx31, regfile or relevant forwards for x0
   a_dummy_opa_mux_check:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     if_id_pipe_i.instr_meta.dummy |-> ( ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_LFSR)    && (rf_raddr_o[0] != '0))  ||
-                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[0] == 0))   ||
-                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_FW_EX)   && (rf_raddr_o[0] == 0))   ||
-                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_FW_WB)   && (rf_raddr_o[0] == 0))))
+                     if_id_pipe_i.instr_meta.dummy |-> ( ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_LFSR)    && (rf_raddr_o[0] != 'b0))  ||
+                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[0] == 'b0))   ||
+                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_FW_EX)   && (rf_raddr_o[0] == 'b0))   ||
+                                                         ((ctrl_byp_i.operand_a_fw_mux_sel == SEL_FW_WB)   && (rf_raddr_o[0] == 'b0))))
       else `uvm_error("id_stage", "Illegal operand a mux select value for dummy instruction")
 
   // LFSR should be used for x1-bx31, regfile or relevant forwards for x0
   a_dummy_opb_mux_check:
     assert property (@(posedge clk) disable iff (!rst_n)
-                     if_id_pipe_i.instr_meta.dummy |-> ( ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_LFSR)    && (rf_raddr_o[1] != '0))  ||
-                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[1] == 0))   ||
-                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_FW_EX)   && (rf_raddr_o[1] == 0))   ||
-                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_FW_WB)   && (rf_raddr_o[1] == 0))))
+                     if_id_pipe_i.instr_meta.dummy |-> ( ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_LFSR)    && (rf_raddr_o[1] != 'b0))  ||
+                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_REGFILE) && (rf_raddr_o[1] == 'b0))   ||
+                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_FW_EX)   && (rf_raddr_o[1] == 'b0))   ||
+                                                         ((ctrl_byp_i.operand_b_fw_mux_sel == SEL_FW_WB)   && (rf_raddr_o[1] == 'b0))))
       else `uvm_error("id_stage", "Illegal operand b mux select value for dummy instruction")
 
 

--- a/sva/cv32e40s_if_stage_sva.sv
+++ b/sva/cv32e40s_if_stage_sva.sv
@@ -29,6 +29,7 @@ module cv32e40s_if_stage_sva
 
   input logic           if_ready,
   input logic           if_valid_o,
+  input logic           id_ready_i,
   input logic [31:0]    pc_if_o,
   input logic           prefetch_resp_valid,
   input ctrl_fsm_t      ctrl_fsm_i,
@@ -109,7 +110,7 @@ module cv32e40s_if_stage_sva
   //       this assertion should be updated to check for guaranteed progress
   a_no_back_to_back_dummy_instructions :
     assert property (@(posedge clk) disable iff (!rst_n)
-                     dummy_insert |-> !$past(dummy_insert))
+                     dummy_insert && (if_valid_o && id_ready_i) |=> !dummy_insert)
       else `uvm_error("if_stage", "Two dummy instructions in a row")
 
   // Assert that we do not trigger dummy instructions when the sequencer is in the middle of a sequence

--- a/sva/cv32e40s_register_file_sva.sv
+++ b/sva/cv32e40s_register_file_sva.sv
@@ -38,7 +38,8 @@ module cv32e40s_register_file_sva
    input logic [REGFILE_WORD_WIDTH-1:0] wdata_i   [REGFILE_NUM_WRITE_PORTS],
    input logic [REGFILE_WORD_WIDTH-1:0] rdata_o   [REGFILE_NUM_READ_PORTS],
    input logic [REGFILE_WORD_WIDTH-1:0] mem_gated [REGFILE_NUM_WORDS],
-   input logic [REGFILE_WORD_WIDTH-1:0] mem       [REGFILE_NUM_WORDS]
+   input logic [REGFILE_WORD_WIDTH-1:0] mem       [REGFILE_NUM_WORDS],
+   input logic                          dummy_instr_wb_i
    );
 
   function bit check_ecc_syndrome (logic [REGFILE_WORD_WIDTH-1:0] data);
@@ -96,7 +97,14 @@ module cv32e40s_register_file_sva
             else `uvm_error("register_file", $sformatf("ECC error for register word x%d", i))
       end
 
+      // If no dummy is in WB, mem[0] shall remain stable
+      a_stable_x0_nondummy:
+        assert property (@(posedge clk) disable iff (!rst_n)
+                        !dummy_instr_wb_i |=> $stable(mem[0]))
+            else `uvm_error("register file", "mem[0] changed for non-dummy instruction")
+
     end
+
   endgenerate
 
 endmodule : cv32e40s_register_file_sva


### PR DESCRIPTION
Added forwarding of x0 from dummies writing x0 to dummies reading x0. No cross forwarding between dummies and regular instructions, and no forwarding of x0 between regular instructions.

Fixed bug where the x0 flops for dummies would be reset to 0 if no dummy was in WB.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>