### PR TITLE
Updates to mret/xinhv handling.

### DIFF
--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -112,7 +112,6 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   // Privilege level for the IF stage
   privlvl_t instr_priv_lvl_q;
 
-  // CLIC vectoring (and Zc table jumps)
   // Flag for signalling that results is a CLIC function pointer
   logic is_clic_ptr_q;
   // Flag for table jump pointer

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -147,6 +147,7 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   //TODO:OK:low This CSR stall check is very restrictive
   //         Should only check EX vs WB, and also CSR/rd addr
   //         Also consider whether ID or EX should be stalled
+  // The controller mechanism for checking mcause.mpp/mcause.minhv when an mret is in the ID stage depends on this stall.
   // Detect when a CSR insn is in ID (including WFI which reads mstatus.tw and priv level)
   // Note that hazard detection uses the registered instr_valid signals. Usage of the local
   // instr_valid signals would lead to a combinatorial loop via the halt signal.

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -1548,6 +1548,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
           mcause_n       = ctrl_fsm_i.csr_cause;
 
+
           if (SMCLIC) begin
             // mpil is saved from mintstatus
             mcause_n.mpil = mintstatus_rdata.mil;
@@ -1567,7 +1568,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           end else begin
             mcause_n.mpil = '0;
           end
-
           mcause_we = 1'b1;
 
         end
@@ -1601,18 +1601,27 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         mstatus_we     = 1'b1;
 
       end //ctrl_fsm_i.csr_restore_dret
-
-      // mcause.minhv shall be cleared if vector fetch is successful
-      ctrl_fsm_i.csr_clear_minhv: begin
-        if (SMCLIC) begin
-          mcause_n = mcause_rdata;
-          mcause_n.minhv = 1'b0;
-          mcause_we = 1'b1;
-        end
-      end
-
       default:;
     endcase
+
+    // mcause.minhv shall be cleared if vector fetch is successful
+    // Not part of the above unique case, as csr_clear_minv and csr_restore_mret
+    // may happen at the same time when an mret is executed when mcause.minhv==1
+    // -- In this case, the mret may be in WB while the controller FSM is in POINTER state
+    //    and a successful pointer fetch is in the ID stage (clears mcause.minhv).
+    // The fields mstatus.mpp and mstatus.mpie er aliased between mcause and mstatus. The mcause write
+    // due to csr_celar_minhv will however only write to mcause.minhv, and no updates to mstatus.mpp/mpie.
+    if (ctrl_fsm_i.csr_clear_minhv) begin
+      if (SMCLIC) begin
+        // Keep mcause values, only clear minhv bit.
+        // Note that mcause_rdata may have the wrong values for mpp and mpie if an mret is also in WB.
+        //  - This is ok as the aliased mpp/mpie bits are stored in mstatus and not mcause, and the clearing
+        //    of minhv does not attempt to change mcause.mpp/mpie.
+        mcause_n = mcause_rdata;
+        mcause_n.minhv = 1'b0;
+        mcause_we = 1'b1;
+      end
+    end
   end
 
   // Mirroring mstatus_n to mnxti_n for RVFI

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -1611,8 +1611,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     //    and a successful pointer fetch is in the ID stage (clears mcause.minhv).
     // The fields mstatus.mpp and mstatus.mpie er aliased between mcause and mstatus. The mcause write
     // due to csr_celar_minhv will however only write to mcause.minhv, and no updates to mstatus.mpp/mpie.
-    if (ctrl_fsm_i.csr_clear_minhv) begin
-      if (SMCLIC) begin
+    if (SMCLIC) begin
+      if (ctrl_fsm_i.csr_clear_minhv) begin
         // Keep mcause values, only clear minhv bit.
         // Note that mcause_rdata may have the wrong values for mpp and mpie if an mret is also in WB.
         //  - This is ok as the aliased mpp/mpie bits are stored in mstatus and not mcause, and the clearing

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -702,12 +702,14 @@ if (SMCLIC) begin
                                                                       (ctrl_fsm_o.pc_mux == PC_TRAP_NMI))))
     else `uvm_error("controller", "Illegal pc_mux after pointer fetch")
 
-  // Check that EX and WB are empty when an mret does it's jump when mcause.minhv is set
-  a_minhv_ex_wb_pipeline_empty:
+  // Check that EX and WB does not contain any instruction with possible exceptions when a mret which restarts a pointer fetch is performed
+  a_jump_no_exceptions:
   assert property (@(posedge clk) disable iff (!rst_n)
-                  (ctrl_fsm_o.pc_set && ctrl_fsm_o.pc_mux == PC_MRET) && mcause_i.minhv
-                  |-> !(id_ex_pipe_i.instr_valid || ex_wb_pipe_i.instr_valid))
-    else `uvm_error("controller", "EX and WB not empty on mret with mcause.minhv set")
+                  (ctrl_fsm_o.pc_set && ctrl_fsm_o.pc_mux == PC_MRET) && ctrl_fsm_o.pc_set_clicv
+                  |->
+                  !(id_ex_pipe_i.instr_valid && (id_ex_pipe_i.abort_op)) &&
+                  !(ex_wb_pipe_i.instr_valid && (ex_wb_pipe_i.abort_op || lsu_err_wb_i || (lsu_mpu_status_wb_i != MPU_OK))))
+    else `uvm_error("controller", "EX and WB may cause exceptions when mret with mcause.minhv is performed")
 
 end // SMCLIC
 
@@ -846,5 +848,29 @@ end // SMCLIC
   assert property (@(posedge clk) disable iff (!rst_n)
                     (ctrl_fsm_cs == SLEEP) |-> !ctrl_byp_i.irq_enable_stall)
     else `uvm_error("controller", "irq_enable_stall while SLEEPING should not happen.")
+
+  // Handling of mret in ID requires mcause.minhv to be stable
+  // This assertion checks that both operations of secure mrets in ID see the same mcause.minhv.
+  a_mret_id_ex_minhv_stable:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (id_valid_i && ex_ready_i && sys_en_id_i && sys_mret_id_i)
+                    |=>
+                    $stable(mcause_i.minhv))
+    else `uvm_error("controller", "mcause.minhv not stable when mret goes from ID to EX")
+
+/* todo: Fix or remove assertion. Will fail for the following scenario:
+    1: mret (1/2) in ID restarts pointer fetch due to mpp and minhv conditions.
+    2: mret (1/2) ID->EX, mret (2/2) in ID  [pointer may be in IF]
+    3: mret (1/2) EX->WB, mret (2/2) in EX  [pointer may be in ID, if successful minhv is cleared]
+    4: mret (2/2) EX->WB, minhv not stable due to clearing by pointer in previous cycle.
+    The not stable minhv is a side effect of the mret itself, so it could be considered a self-stall which
+    normally will not cause halts.
+  a_mret_ex_wb_minhv_stable:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                    (ex_valid_i && wb_ready_i && id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn)
+                    |=>
+                    $stable(mcause_i.minhv))
+    else `uvm_error("controller", "mcause.minhv not stable when mret goes from EX to WB")
+*/
 endmodule
 

--- a/sva/cv32e40s_cs_registers_sva.sv
+++ b/sva/cv32e40s_cs_registers_sva.sv
@@ -149,5 +149,48 @@ module cv32e40s_cs_registers_sva
 
   a_halt_limited_wb: assert property(p_halt_limited_wb)
     else `uvm_error("cs_registers", "CSR in WB while halt_limited_wb is set");
+
+  // Check that mcause is not written when an mret or dret is in WB
+  property p_mret_dret_wb_mcause_write;
+    @(posedge clk) disable iff (!rst_n)
+    (  (ctrl_fsm_i.csr_restore_mret || ctrl_fsm_i.csr_restore_dret) && !ctrl_fsm_i.csr_clear_minhv |-> !mcause_we);
+  endproperty;
+
+  a_mret_dret_wb_mcause_write: assert property(p_mret_dret_wb_mcause_write)
+    else `uvm_error("cs_registers", "mcause written when MRET or DRET is in WB.");
+
+  // Check csr_clear_minhv cannot happen at the same time as csr_save_cause or csr_restore_dret (would cause mcause_we conflict)
+  property p_minhv_unique;
+    @(posedge clk) disable iff (!rst_n)
+    (  ctrl_fsm_i.csr_clear_minhv -> !(ctrl_fsm_i.csr_save_cause || ctrl_fsm_i.csr_restore_dret));
+  endproperty;
+
+  a_minhv_unique: assert property(p_minhv_unique)
+    else `uvm_error("cs_registers", "csr_save_cause at the same time as csr_clear_minhv.");
+
+
+  // Check EX is empty or contains last part of mret when minhv is cleared
+  property p_ex_empty_minhv_clear;
+    @(posedge clk) disable iff (!rst_n)
+    (  ctrl_fsm_i.csr_clear_minhv
+       -> !id_ex_pipe_i.instr_valid       // No valid instruction in EX
+       or
+          (id_ex_pipe_i.instr_valid && id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && id_ex_pipe_i.last_op)); // Last part of hardened mret in EX
+  endproperty;
+
+  a_ex_empty_minhv_clear: assert property(p_ex_empty_minhv_clear)
+    else `uvm_error("cs_registers", "EX not empty when csr_clear_minhv is active.");
+
+  // Check WB is empty or contains any part of mret when minhv is cleared
+  property p_wb_empty_minhv_clear;
+    @(posedge clk) disable iff (!rst_n)
+    (  ctrl_fsm_i.csr_clear_minhv
+        -> !ex_wb_pipe_i.instr_valid       // No valid instruction in WB
+        or
+          (ex_wb_pipe_i.instr_valid && ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn)); // Any part of hardened mret in WB
+  endproperty;
+
+  a_wb_empty_minhv_clear: assert property(p_wb_empty_minhv_clear)
+    else `uvm_error("cs_registers", "WB not empty when csr_clear_minhv is active.");
 endmodule
 


### PR DESCRIPTION
Updated handling of mret related to mcause.mpp and mcause.minhv. No inhv assumes for mpp==PRIV_LVL_U. Unique case violation in cs_registers due to clearing of minhv fixed, assertions added to make sure there is no conflicting writes to mcause.

When merged, this PR will be cherry picked to the E40X to apply the changes there. Should fix issue #498 on CV32E40X when done.