### PR TITLE
Fixes after merging from CV32E40X

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -357,7 +357,7 @@ module cv32e40s_wrapper
                 .mret_self_stall_bypass           (core_i.controller_i.bypass_i.mret_self_stall),
                 .jumpr_self_stall_bypass          (core_i.controller_i.bypass_i.jumpr_self_stall),
                 .last_sec_op_id_i                 (core_i.id_stage_i.last_sec_op),
-                .last_op_id                       (core_i.id_stage_i.last_op),
+                .last_op_id                       (core_i.id_stage_i.last_op_o),
                 .mie_n                            (core_i.cs_registers_i.mie_n),
                 .mie_we                           (core_i.cs_registers_i.mie_we),
                 .*);

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -167,15 +167,17 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   // Using qualified or unqualified from ID does not matter for the value of the self_stall (assert in core_sva).
   // ctrl_byp_o.deassert_we needs to be 1 for the sys_en to be deasserted, and this cannot
   // happen for the last part (ID) if it didn't already happen to the first part (EX or WB).
+  // Note that if an mret restarts a CLIC pointer fetch, the second part of the mret with last_sec_op == 1
+  // will have last_op == 0, the final step carrying the pointer will be marked with last_op == 1.
   //
   // Last line excludes setting the self stall signal in case a last part of an mret is in EX stage.
   // - Last part of mret in EX means any mret in ID must a different mret instruction.
   // - This mret must then be flagged as faulted (deassert_we=1) for it to have last_sec_op_id_i set. Any csr_stall will then be active, although
   // - the instruction will not do any side effects and eventually take an exception when it reaches WB.
   assign mret_self_stall = ((sys_mret_unqual_id && last_sec_op_id_i) && // MRET 2/2 in ID
-                           ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_op && id_ex_pipe_i.instr_valid) ||    // mret 1/2 in EX
-                            (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && !ex_wb_pipe_i.last_op && ex_wb_pipe_i.instr_valid))) &&  // mret 1/2 in WB
-                            !(id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && id_ex_pipe_i.last_op && id_ex_pipe_i.instr_valid);
+                           ((id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && !id_ex_pipe_i.last_sec_op && id_ex_pipe_i.instr_valid) ||    // mret 1/2 in EX
+                            (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn && !ex_wb_pipe_i.last_sec_op && ex_wb_pipe_i.instr_valid))) &&  // mret 1/2 in WB
+                            !(id_ex_pipe_i.sys_en && id_ex_pipe_i.sys_mret_insn && id_ex_pipe_i.last_sec_op && id_ex_pipe_i.instr_valid);
 
 
   // Detect if a jumpr instruction is stalling on itself (Can only happen if the last part is in ID and the first in EX)
@@ -184,7 +186,7 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
   // happen for the last part (ID) if it didn't already happen to the first part (EX or WB).
   // Using unqualified or qualified jumpr get the same result. (Assert in core_sva)
   assign jumpr_self_stall = (jmpr_unqual_id && last_sec_op_id_i) &&
-                            ((id_ex_pipe_i.alu_jmp && id_ex_pipe_i.alu_en && !id_ex_pipe_i.last_op && id_ex_pipe_i.instr_valid));
+                            ((id_ex_pipe_i.alu_jmp && id_ex_pipe_i.alu_en && !id_ex_pipe_i.last_sec_op && id_ex_pipe_i.instr_valid));
 
 
   // Stall ID when WFI or WFE is active in EX.

--- a/rtl/cv32e40s_ex_stage.sv
+++ b/rtl/cv32e40s_ex_stage.sv
@@ -390,6 +390,7 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
       ex_wb_pipe_o.xif_meta           <= '0;
       ex_wb_pipe_o.first_op           <= 1'b0;
       ex_wb_pipe_o.last_op            <= 1'b0;
+      ex_wb_pipe_o.last_sec_op        <= 1'b0;
       ex_wb_pipe_o.abort_op           <= 1'b0;
     end
     else
@@ -398,6 +399,7 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
         ex_wb_pipe_o.instr_valid <= 1'b1;
 
         ex_wb_pipe_o.last_op     <= last_op_o;
+        ex_wb_pipe_o.last_sec_op <= id_ex_pipe_i.last_sec_op;
         ex_wb_pipe_o.first_op    <= first_op_o;
         ex_wb_pipe_o.abort_op    <= id_ex_pipe_i.abort_op; // MPU exceptions have WB timing and will not impact ex_wb_pipe.abort_op
         // Deassert rf_we in case of illegal csr instruction or

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -585,6 +585,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
 
       id_ex_pipe_o.first_op               <= 1'b0;
       id_ex_pipe_o.last_op                <= 1'b0;
+      id_ex_pipe_o.last_sec_op            <= 1'b0;
       id_ex_pipe_o.abort_op               <= 1'b0;
     end else begin
       // normal pipeline unstall case
@@ -592,6 +593,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
         id_ex_pipe_o.priv_lvl     <= if_id_pipe_i.priv_lvl;
         id_ex_pipe_o.instr_valid  <= 1'b1;
         id_ex_pipe_o.last_op      <= last_op_o;
+        id_ex_pipe_o.last_sec_op  <= last_sec_op;
         id_ex_pipe_o.first_op     <= first_op_o;
         id_ex_pipe_o.abort_op     <= abort_op_o;
 

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -505,12 +505,13 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
           if_id_pipe_o.pc                    <= pc_if_o;
           // Sequenced instructions are marked as illegal by the compressed decoder, however, the instr_compressed
           // flag is still set and can be used when propagating to ID.
+          // Dummy instructions are never marked as compressed or tablejumps.
           if_id_pipe_o.instr_meta.compressed <= dummy_insert ? 1'b0 : instr_compressed;
-          if_id_pipe_o.instr_meta.tbljmp     <= seq_tbljmp;
+          if_id_pipe_o.instr_meta.tbljmp     <= dummy_insert ? 1'b0 : seq_tbljmp;
 
           // Only update compressed_instr for compressed instructions
           if (instr_compressed) begin
-            if_id_pipe_o.compressed_instr      <= prefetch_instr.bus_resp.rdata[15:0];
+            if_id_pipe_o.compressed_instr    <= prefetch_instr.bus_resp.rdata[15:0];
           end
         end
 

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1300,6 +1300,7 @@ typedef struct packed {
 
   logic         first_op;         // First part of multi operation instruction
   logic         last_op;          // Last part of multi operation instruction
+  logic         last_sec_op;      // Last part of SECURE jump/mret/branch. (NB: mret may have last_sec_op && !last_op in case it caused a pointer fetch)
   logic         abort_op;         // Instruction will be aborted due to known exceptions or trigger matches
 
 } id_ex_pipe_t;
@@ -1350,6 +1351,7 @@ typedef struct packed {
 
   logic         first_op;         // First part of multi operation instruction
   logic         last_op;          // Last part of multi operation instruction
+  logic         last_sec_op;      // Last part of SECURE jump/mret/branch. (NB: mret may have last_sec_op && !last_op in case it caused a pointer fetch)
   logic         abort_op;         // Instruction will be aborted due to known exceptions or trigger matches
 } ex_wb_pipe_t;
 

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -345,7 +345,7 @@ module cv32e40s_controller_fsm_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                       // Disregard higher priority exceptions and trigger match
                       !(((ex_wb_pipe_i.instr.mpu_status != MPU_OK) || ex_wb_pipe_i.instr.bus_resp.err || trigger_match_in_wb) && ex_wb_pipe_i.instr_valid) &&
-                      !(ex_wb_pipe_i.instr_meta.clic_ptr) && !ctrl_fsm_o.debug_mode &&
+                      !(ex_wb_pipe_i.instr_meta.clic_ptr || ex_wb_pipe_i.instr_meta.mret_ptr) && !ctrl_fsm_o.debug_mode &&
                       // Check for mret in instruction word and user mode
                       ((ex_wb_pipe_i.instr.bus_resp.rdata == 32'h30200073) && ex_wb_pipe_i.instr_valid && (priv_lvl_i == PRIV_LVL_M))
                       |-> (!exception_in_wb && (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn)))


### PR DESCRIPTION
Using last_sec_op instead of last_op when detecting mret_self_stall in controller bypass. Update done because an mret which restarts pointer fetch will not signal last_op until the pointer arrives. Using last_op when checking for mret_self_stall will then not be correct.

Not setting instr_meta.tbljmp for dummy instructions.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>