### PR TITLE
Interface integrity instruction achk

### DIFF
--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -165,7 +165,7 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
       ^{m_c_obi_instr_if.req_payload.addr[31:24]},
       ^{m_c_obi_instr_if.req_payload.addr[23:16]},
       ^{m_c_obi_instr_if.req_payload.addr[15:8]},
-      ^{m_c_obi_instr_if.req_payload.addr[7:2], 2'b00} // Bits 1:0 are tied to zero in the core level.
+      ^{m_c_obi_instr_if.req_payload.addr[7:2]}
     };
   end
 

--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -165,7 +165,7 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
       ^{m_c_obi_instr_if.req_payload.addr[31:24]},
       ^{m_c_obi_instr_if.req_payload.addr[23:16]},
       ^{m_c_obi_instr_if.req_payload.addr[15:8]},
-      ^{m_c_obi_instr_if.req_payload.addr[7:2]}
+      ^{m_c_obi_instr_if.req_payload.addr[7:0]}
     };
   end
 


### PR DESCRIPTION
I have removed the tie-off of the achk variabel so that we generate the correct value. It seams like pointers dont necessarily have the two LSB address bits tied off to 0. 