### PR TITLE
Merge from CV32E40X

### DIFF
--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -521,7 +521,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
   // Debug pending for any other synchronous reason than single step
   assign pending_sync_debug = (trigger_match_in_wb) ||
-                              (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) || // Ebreak with dcsr.ebreakm==1 // todo: add check for WB stage priv level
+                              (ebreak_in_wb && dcsr_i.ebreakm && (ex_wb_pipe_i.priv_lvl == PRIV_LVL_M) && !debug_mode_q) || // Ebreak with dcsr.ebreakm==1  during machine mode
                               (ebreak_in_wb && debug_mode_q); // Ebreak during debug_mode restarts execution from dm_halt_addr, as a regular debug entry without CSR updates.
 
   // Debug pending for external debug request, only if not already in debug mode
@@ -542,11 +542,11 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // 4: trigger match (0x2)
   // 5: ebreak (0x1)
   // 6: single step (0x4)
-  assign debug_cause_n = (trigger_match_in_wb || etrigger_wb_i)            ? DBG_CAUSE_TRIGGER :    // Etrigger will enter DEBUG_TAKEN as a single step (no halting), but kill pipeline as non-stepping entries.
-                         (ebreak_in_wb && dcsr_i.ebreakm && !debug_mode_q) ? DBG_CAUSE_EBREAK  :    // Ebreak during machine mode
-                         (ebreak_in_wb && debug_mode_q)                    ? DBG_CAUSE_EBREAK  :    // Ebreak during debug mode
-                         (pending_async_debug && async_debug_allowed)      ? DBG_CAUSE_HALTREQ :
-                         (pending_single_step && single_step_allowed)      ? DBG_CAUSE_STEP    : DBG_CAUSE_NONE;
+  assign debug_cause_n = (trigger_match_in_wb || etrigger_wb_i)                                                     ? DBG_CAUSE_TRIGGER :    // Etrigger will enter DEBUG_TAKEN as a single step (no halting), but kill pipeline as non-stepping entries.
+                         (ebreak_in_wb && dcsr_i.ebreakm && (ex_wb_pipe_i.priv_lvl == PRIV_LVL_M) && !debug_mode_q) ? DBG_CAUSE_EBREAK  :    // Ebreak during machine mode
+                         (ebreak_in_wb && debug_mode_q)                                                             ? DBG_CAUSE_EBREAK  :    // Ebreak during debug mode
+                         (pending_async_debug && async_debug_allowed)                                               ? DBG_CAUSE_HALTREQ :
+                         (pending_single_step && single_step_allowed)                                               ? DBG_CAUSE_STEP    : DBG_CAUSE_NONE;
 
 
   // Debug cause to CSR from flopped version (valid during DEBUG_TAKEN)

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1571,8 +1571,8 @@ typedef struct packed {
 
   function automatic logic[1:0] mtvec_mode_clic_resolve
   (
-    logic current_value,
-    logic next_value
+    logic [1:0] current_value,
+    logic [1:0] next_value
   );
     // mtvec.mode is WARL(0x3) in CLIC mode
     return 2'b11;


### PR DESCRIPTION
Not SEC clean as there is currently a bug on master that causes e40s enter debug mode on an ebreak with dcsr.ebreakm set regardless of the current privilege level (which is fixed with this merge).

