### PR TITLE
WARL resolve updates and ebreak debug entry for user mode.

### DIFF
--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -522,6 +522,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // Debug pending for any other synchronous reason than single step
   assign pending_sync_debug = (trigger_match_in_wb) ||
                               (ebreak_in_wb && dcsr_i.ebreakm && (ex_wb_pipe_i.priv_lvl == PRIV_LVL_M) && !debug_mode_q) || // Ebreak with dcsr.ebreakm==1  during machine mode
+                              (ebreak_in_wb && dcsr_i.ebreaku && (ex_wb_pipe_i.priv_lvl == PRIV_LVL_U) && !debug_mode_q) || // Ebreak with dcsr.ebreaku==1  during user mode
                               (ebreak_in_wb && debug_mode_q); // Ebreak during debug_mode restarts execution from dm_halt_addr, as a regular debug entry without CSR updates.
 
   // Debug pending for external debug request, only if not already in debug mode
@@ -544,6 +545,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // 6: single step (0x4)
   assign debug_cause_n = (trigger_match_in_wb || etrigger_wb_i)                                                     ? DBG_CAUSE_TRIGGER :    // Etrigger will enter DEBUG_TAKEN as a single step (no halting), but kill pipeline as non-stepping entries.
                          (ebreak_in_wb && dcsr_i.ebreakm && (ex_wb_pipe_i.priv_lvl == PRIV_LVL_M) && !debug_mode_q) ? DBG_CAUSE_EBREAK  :    // Ebreak during machine mode
+                         (ebreak_in_wb && dcsr_i.ebreaku && (ex_wb_pipe_i.priv_lvl == PRIV_LVL_U) && !debug_mode_q) ? DBG_CAUSE_EBREAK  :    // Ebreak during user mode
                          (ebreak_in_wb && debug_mode_q)                                                             ? DBG_CAUSE_EBREAK  :    // Ebreak during debug mode
                          (pending_async_debug && async_debug_allowed)                                               ? DBG_CAUSE_HALTREQ :
                          (pending_single_step && single_step_allowed)                                               ? DBG_CAUSE_STEP    : DBG_CAUSE_NONE;

--- a/rtl/cv32e40s_csr.sv
+++ b/rtl/cv32e40s_csr.sv
@@ -60,8 +60,13 @@ module cv32e40s_csr #(
             cv32e40s_sffs #(.LIB(LIB)) sffs_shadowreg (.clk(clk_gated), .rst_n(rst_n), .d_i(shadow_d[i]), .q_o(shadow_q[i]));
           end
         end else begin : gen_masked
-          assign rdata_q[i]  = 1'b0;
-          assign shadow_q[i] = 1'b1;
+          if (RESETVALUE[i] == 1'b1) begin : gen_constant_1
+            assign rdata_q[i]  = 1'b1;
+            assign shadow_q[i] = 1'b0;
+          end else begin : gen_constant_0
+            assign rdata_q[i]  = 1'b0;
+            assign shadow_q[i] = 1'b1;
+          end
         end
       end
 

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -467,7 +467,7 @@ typedef enum logic[11:0] {
 
 // CSR Bit Implementation Masks
 parameter CSR_JVT_MASK          = 32'hFFFFFC00;
-parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1000_1001_1100_0111; // NMI bit taken from ctrl_fsm
+parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1001_1101_1101_0111; // NMI bit taken from ctrl_fsm
 parameter CSR_MEPC_MASK         = 32'hFFFFFFFE;
 parameter CSR_DPC_MASK          = 32'hFFFFFFFE;
 //        CSR_MIE_MASK          = IRQ_MASK;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -467,13 +467,13 @@ typedef enum logic[11:0] {
 
 // CSR Bit Implementation Masks
 parameter CSR_JVT_MASK          = 32'hFFFFFC00;
-parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1001_1101_1101_0111; // NMI bit taken from ctrl_fsm
+parameter CSR_DCSR_MASK         = 32'b1111_0000_0000_0000_1001_1101_1100_0111; // NMI bit taken from ctrl_fsm
 parameter CSR_MEPC_MASK         = 32'hFFFFFFFE;
 parameter CSR_DPC_MASK          = 32'hFFFFFFFE;
 //        CSR_MIE_MASK          = IRQ_MASK;
 parameter CSR_MSTATUS_MASK      = 32'b0000_0000_0010_0010_0001_1000_1000_1000;
 parameter CSR_MTVEC_BASIC_MASK  = 32'hFFFFFF81;
-parameter CSR_MTVEC_CLIC_MASK   = 32'hFFFFFF83;
+parameter CSR_MTVEC_CLIC_MASK   = 32'hFFFFFF80;
 parameter CSR_MTVT_MASK         = 32'hFFFFFFE0;
 parameter CSR_MINTSTATUS_MASK   = 32'hFF000000;
 parameter CSR_MSCRATCH_MASK     = 32'hFFFFFFFF;

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1515,8 +1515,8 @@ typedef struct packed {
     logic       current_value,
     logic       next_value
   );
-    // dcsr.ebreaku is WARL(0x0)
-    return 1'b0;
+    // dcsr.ebreaku is WARL
+    return next_value;
   endfunction
 
   function automatic logic [1:0] mstatus_mpp_resolve
@@ -1533,8 +1533,8 @@ typedef struct packed {
     logic current_value,
     logic next_value
   );
-    // mstatus.mprv is WARL(0x0)
-    return 1'b0;
+    // mstatus.mprv is is RW
+    return next_value;
   endfunction
 
   function automatic logic [3:0] mcontrol6_match_resolve
@@ -1548,16 +1548,16 @@ typedef struct packed {
   (
     logic next_value
   );
-    // mcontrol6.u is WARL(0x0)
-    return 1'b0;
+    // mcontrol6.u is WARL
+    return next_value;
   endfunction
 
   function automatic logic etrigger_u_resolve
   (
     logic next_value
   );
-    // etrigger.u is WARL(0x0)
-    return 1'b0;
+    // etrigger.u is WARL
+    return next_value;
   endfunction
 
   function automatic logic[1:0] mtvec_mode_clint_resolve


### PR DESCRIPTION
Updated WARL resolve functions to match supported values by e40s.
Added support for entering debug on ebreak during user mode when dcsr.ebreaku is set.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>