### PR TITLE
Signal instruction PMP error on RVFI

### DIFF
--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -724,6 +724,7 @@ module cv32e40s_rvfi
     .prefetch_compressed_i      ( prefetch_compressed_if_i      ),
     .kill_if_i                  ( ctrl_fsm_i.kill_if            ),
     .mpu_status_i               ( mpu_status_i                  ),
+    .pmp_err_i                  ( instr_pmp_err_if_i            ),
     .prefetch_trans_valid_i     ( prefetch_trans_valid_i        ),
     .prefetch_trans_ready_i     ( prefetch_trans_ready_i        ),
     .prefetch_resp_valid_i      ( prefetch_resp_valid_i         ),
@@ -912,7 +913,7 @@ module cv32e40s_rvfi
       //// IF Stage ////
       if (if_valid_i && id_ready_i) begin
         debug_mode [STAGE_ID] <= ctrl_fsm_i.debug_mode; // Probing in IF to ensure LSU instructions that are not killed can complete
-        instr_pmp_err[STAGE_ID] <= instr_pmp_err_if_i;    // Instruction fetch pmp error probed to separate pmp- from pma-errors
+        instr_pmp_err[STAGE_ID] <= obi_instr_if.pmp_err;    // Instruction fetch pmp error probed to separate pmp- from pma-errors
 
         // Capturing events that happen when the IF stage is not valid and
         // propagating them through the pipeline with the next valid instruction

--- a/bhv/cv32e40s_rvfi_instr_obi.sv
+++ b/bhv/cv32e40s_rvfi_instr_obi.sv
@@ -33,6 +33,7 @@ module cv32e40s_rvfi_instr_obi import cv32e40s_pkg::*; import cv32e40s_rvfi_pkg:
   input  logic [31:0]                   prefetch_addr_i,
   input  logic                          prefetch_compressed_i,
   input  logic                          kill_if_i,
+  input  logic                          pmp_err_i,
   input  mpu_status_e                   mpu_status_i,
   input logic                           prefetch_trans_valid_i,
   input logic                           prefetch_trans_ready_i,
@@ -143,6 +144,7 @@ module cv32e40s_rvfi_instr_obi import cv32e40s_pkg::*; import cv32e40s_rvfi_pkg:
   begin
     fifo_req_n = fifo_q[wptr_req_q];
     fifo_req_n.req_payload = m_c_obi_instr_if.req_payload;
+    fifo_req_n.pmp_err = pmp_err_i; // pmp_err_i is valid when the MPU accepts a transfer
     wptr_req_n = wptr_req_q + 1'b1;
   end
 
@@ -211,7 +213,8 @@ module cv32e40s_rvfi_instr_obi import cv32e40s_pkg::*; import cv32e40s_rvfi_pkg:
     if (prefetch_compressed_i) begin
       if (prefetch_addr_i[1:0] == 2'b00) begin
         // Compressed instruction in LSBs of 1 rdata item
-        obi_instr.req_payload               =  fifo_q[rptr_q].req_payload;
+        obi_instr.req_payload                        =  fifo_q[rptr_q].req_payload;
+        obi_instr.pmp_err                            =  fifo_q[rptr_q].pmp_err;
         obi_instr.resp_payload.bus_resp.rdata[31:16] =  16'h0;
         obi_instr.resp_payload.bus_resp.rdata[15:0]  =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.rdata[15:0]  : fifo_q[rptr_q].resp_payload.bus_resp.rdata[15:0];
         obi_instr.resp_payload.bus_resp.err          =  (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.err          : fifo_q[rptr_q].resp_payload.bus_resp.err;
@@ -219,6 +222,7 @@ module cv32e40s_rvfi_instr_obi import cv32e40s_pkg::*; import cv32e40s_rvfi_pkg:
       end else begin
         // Compressed instruction in MSBs of 1 rdata item
         obi_instr.req_payload                        = fifo_q[rptr_q].req_payload;
+        obi_instr.pmp_err                            = fifo_q[rptr_q].pmp_err;
         obi_instr.resp_payload.bus_resp.rdata[31:16] = 16'h0;
         obi_instr.resp_payload.bus_resp.rdata[15:0]  = (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.rdata[31:16] : fifo_q[rptr_q].resp_payload.bus_resp.rdata[31:16];
         obi_instr.resp_payload.bus_resp.err          = (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.err          : fifo_q[rptr_q].resp_payload.bus_resp.err;
@@ -228,6 +232,7 @@ module cv32e40s_rvfi_instr_obi import cv32e40s_pkg::*; import cv32e40s_rvfi_pkg:
       if (prefetch_addr_i[1:0] == 2'b00) begin
         // Uncompressed instruction (or pointer) in 1 rdata item
         obi_instr.req_payload                        = fifo_q[rptr_q].req_payload;
+        obi_instr.pmp_err                            = fifo_q[rptr_q].pmp_err;
         obi_instr.resp_payload.bus_resp.rdata[31:16] = (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.rdata[31:16] : fifo_q[rptr_q].resp_payload.bus_resp.rdata[31:16];
         obi_instr.resp_payload.bus_resp.rdata[15:0]  = (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.rdata[15:0]  : fifo_q[rptr_q].resp_payload.bus_resp.rdata[15:0];
         obi_instr.resp_payload.bus_resp.err          = (rptr_q     == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.err          : fifo_q[rptr_q].resp_payload.bus_resp.err;
@@ -235,6 +240,7 @@ module cv32e40s_rvfi_instr_obi import cv32e40s_pkg::*; import cv32e40s_rvfi_pkg:
       end else begin
         // Uncompressed instruction (or pointer) in 2 rdata items
         obi_instr.req_payload                        = fifo_q[rptr_q].req_payload;
+        obi_instr.pmp_err                            = fifo_q[rptr_q].pmp_err || fifo_q[rptr_q_inc].pmp_err;
         obi_instr.resp_payload.bus_resp.rdata[31:16] = (rptr_q_inc == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.rdata[15:0]  : fifo_q[rptr_q_inc].resp_payload.bus_resp.rdata[15:0];
         obi_instr.resp_payload.bus_resp.rdata[15:0]  = fifo_q[rptr_q].resp_payload.bus_resp.rdata[31:16];
         obi_instr.resp_payload.bus_resp.err          = ((rptr_q_inc == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.err         : fifo_q[rptr_q_inc].resp_payload.bus_resp.err) ||

--- a/bhv/cv32e40s_rvfi_instr_obi.sv
+++ b/bhv/cv32e40s_rvfi_instr_obi.sv
@@ -240,6 +240,8 @@ module cv32e40s_rvfi_instr_obi import cv32e40s_pkg::*; import cv32e40s_rvfi_pkg:
       end else begin
         // Uncompressed instruction (or pointer) in 2 rdata items
         obi_instr.req_payload                        = fifo_q[rptr_q].req_payload;
+        // Set pmp_err for the instruction if any of the rdata items had a PMP error.
+        // The PMP status for both rdata items are already in the FIFO since PMP errors are captured with the same timing as OBI address phase signals.
         obi_instr.pmp_err                            = fifo_q[rptr_q].pmp_err || fifo_q[rptr_q_inc].pmp_err;
         obi_instr.resp_payload.bus_resp.rdata[31:16] = (rptr_q_inc == wptr_resp_q) ? fifo_resp_n.resp_payload.bus_resp.rdata[15:0]  : fifo_q[rptr_q_inc].resp_payload.bus_resp.rdata[15:0];
         obi_instr.resp_payload.bus_resp.rdata[15:0]  = fifo_q[rptr_q].resp_payload.bus_resp.rdata[31:16];

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -529,7 +529,7 @@ endgenerate
          // IF Probes
          .if_valid_i               ( core_i.if_stage_i.if_valid_o                                         ),
          .pc_if_i                  ( core_i.if_stage_i.pc_if_o                                            ),
-         .instr_pmp_err_if_i       ( 1'b0                          /* TODO: connect */                    ),
+         .instr_pmp_err_if_i       ( core_i.if_stage_i.mpu_i.pmp_err                                      ),
          .last_op_if_i             ( core_i.if_stage_i.last_op_o                                          ),
          .abort_op_if_i            ( core_i.if_stage_i.abort_op_o                                         ),
          .prefetch_valid_if_i      ( core_i.if_stage_i.prefetch_unit_i.prefetch_valid_o                   ),

--- a/bhv/include/cv32e40s_rvfi_pkg.sv
+++ b/bhv/include/cv32e40s_rvfi_pkg.sv
@@ -130,6 +130,7 @@ package cv32e40s_rvfi_pkg;
   typedef struct packed {
     obi_inst_req_t  req_payload;
     inst_resp_t     resp_payload;
+    logic           pmp_err;
   } rvfi_obi_instr_t;
 
 endpackage


### PR DESCRIPTION
Fix for https://github.com/openhwgroup/cv32e40s/issues/333

This update has been verified formally by asserting that we signal PMP error on rvfi_trap.cause_type if and only if we have a instruction access fault. Since PMA can also give instruction access fault, PMA had to be disabled to get the assertions to pass. Because of this, the assertions used to verify this are not checked in.

Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>