### PR TITLE
Using flopped pc_if for dataindependent branches

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -224,6 +224,7 @@ module cv32e40s_wrapper
     core_i.ex_stage_i cv32e40s_ex_stage_sva ex_stage_sva
     (
       .branch_taken_ex_ctrl_i (core_i.controller_i.controller_fsm_i.branch_taken_ex ),
+      .ctrl_flush_ack_n       (core_i.controller_i.controller_fsm_i.csr_flush_ack_n ),
       .*
     );
 

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -639,6 +639,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     // Jumps and branches
     .jmp_target_o                 ( jump_target_id            ),
 
+    .pc_if_i                      ( pc_if                     ),
     // IF/ID pipeline
     .if_id_pipe_i                 ( if_id_pipe                ),
 

--- a/rtl/cv32e40s_ex_stage.sv
+++ b/rtl/cv32e40s_ex_stage.sv
@@ -190,7 +190,11 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
           end
           else begin
             // ID and EX stage both contain the branch instruction, target addr is in IF.
-            branch_target_o = pc_if_i;
+            // Using the IF stage PC as observed when the branch was in ID,
+            // flopped to the id_ex_pipe. This ensures that branch_target_o
+            // remains stable for all parts of a branch when dataindependent
+            // timing is turned on.
+            branch_target_o = id_ex_pipe_i.pc_next;
           end
         end
         else begin

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -47,6 +47,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   // Jumps and branches
   output logic [31:0] jmp_target_o,
 
+  input  logic [31:0] pc_if_i,
   // IF/ID pipeline
   input  if_id_pipe_t if_id_pipe_i,
 
@@ -589,6 +590,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
       id_ex_pipe_o.rf_waddr               <= '0;
 
         // Exceptions and debug
+      id_ex_pipe_o.pc_next                <= 32'b0;
       id_ex_pipe_o.pc                     <= 32'b0;
       id_ex_pipe_o.instr                  <= INST_RESP_RESET_VAL;
       id_ex_pipe_o.instr_meta             <= '0;
@@ -681,6 +683,12 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
         // Exceptions and debug
         id_ex_pipe_o.pc                     <= if_id_pipe_i.pc;
         id_ex_pipe_o.instr_meta             <= if_id_pipe_i.instr_meta;
+
+        // Next PC (pc_if) is only needed for branches in case of
+        // dataindependent timing branches to the next instruction
+        if (alu_bch) begin
+          id_ex_pipe_o.pc_next              <= pc_if_i;
+        end
 
         if (if_id_pipe_i.instr_meta.compressed) begin
           // Overwrite instruction word in case of compressed instruction

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1325,6 +1325,7 @@ typedef struct packed {
   rf_addr_t     rf_waddr;
 
   // Signals for exception handling etc passed on for evaluation in WB stage
+  logic [31:0]  pc_next;          // PC for the following instruction
   logic [31:0]  pc;
   inst_resp_t   instr;            // Contains instruction word (may be compressed),bus error status and MPU status
   instr_meta_t  instr_meta;

--- a/sva/cv32e40s_ex_stage_sva.sv
+++ b/sva/cv32e40s_ex_stage_sva.sv
@@ -49,7 +49,8 @@ module cv32e40s_ex_stage_sva
   input logic           instr_valid,
 
   input logic           branch_taken_ex_ctrl_i,
-  input logic           last_op_o
+  input logic           last_op_o,
+  input logic           ctrl_flush_ack_n
 );
 
   // Halt implies not ready and not valid
@@ -151,22 +152,21 @@ endgenerate
     assert property (@(posedge clk) disable iff (!rst_n)
                      (instr_valid |=> $stable(xsecure_ctrl_i.cpuctrl)));
 
-/*
-  // todo: Commented out as it currently fails for data independent branches taken to next instruction while the branch itself
-  //       is stalled in EX. Possible fix could be to use pc_ex+2/4 instead of pc_if for those branches, or flop the pc_if from ID to EX
-  //       together with the branch instruction.
+
   // Check that branch target remains constant while a branch instruction is in EX
   // Branches are taken during their first un-stalled cycle in EX. If the target changes before
   // the branch can move to WB, we might have taken the branch before an unresolved dependency.
+  // Only checking when ctrl_flush_ack_n is not 1, as this indicates that a CSR write will cause a pipeline flush.
+  //  This CSR write may potentially change the branch target due to changing the cputrl.dataindtiming bit. Branch in EX will be killed.
   property p_bch_target_stable;
     logic [31:0] bch_target;
     @(posedge clk) disable iff (!rst_n)
-    (branch_taken_ex_ctrl_i, bch_target=branch_target_o)
+    (branch_taken_ex_ctrl_i && !ctrl_flush_ack_n, bch_target=branch_target_o)
     |->
     (bch_target == branch_target_o) until_with ((ex_valid_o && wb_ready_i && last_op_o) || ctrl_fsm_i.kill_ex);
   endproperty
 
   a_bch_target_stable: assert property (p_bch_target_stable)
     else `uvm_error("ex_stage", "Branch target not stable")
-*/
+
 endmodule


### PR DESCRIPTION
Flopping pc_if into id_ex_pipe for branches. This is then used as the target for non-taken dataindependent branches. This ensures stability of the branch target for all cycles of a branch in EX, and the pc hardening feature will check pc_if vs the id_ex_pipe.pc_next instead of pc_if vs pc_if as it was.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>