### PR TITLE
Implement turning on and off PC hardening.

### DIFF
--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -101,6 +101,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
 
   input logic  [1:0]  mtvec_mode_i,
   input  mcause_t     mcause_i,
+  input  xsecure_ctrl_t xsecure_ctrl_i,
 
   input  logic        etrigger_wb_i,
 
@@ -223,6 +224,7 @@ module cv32e40s_controller import cv32e40s_pkg::*;
     .debug_req_i                 ( debug_req_i              ),
     .dcsr_i                      ( dcsr_i                   ),
     .mcause_i                    ( mcause_i                 ),
+    .xsecure_ctrl_i              ( xsecure_ctrl_i           ),
 
     // Fencei flush handshake
     .fencei_flush_ack_i          ( fencei_flush_ack_i       ),

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -587,7 +587,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // Allowing NMI's follow the same rule as regular interrupts, except we don't need to regard blanking of NMIs after a load/store.
   // If the core woke up from sleep due to either debug or regular interrupts, the wakeup reason is honored by not allowing NMIs in the cycle after
   // waking up to such an event.
-  assign nmi_allowed = lsu_interruptible_i && debug_interruptible && !fencei_ongoing && !xif_in_wb && !clic_ptr_in_pipeline && sequence_interruptible && !(woke_to_debug_q || woke_to_interrupt_q || csr_flush_ack_q);
+  assign nmi_allowed = lsu_interruptible_i && debug_interruptible && !fencei_ongoing && !xif_in_wb && !clic_ptr_in_pipeline && sequence_interruptible && !(woke_to_debug_q || woke_to_interrupt_q) && !csr_flush_ack_q;
 
   // Do not allow interrupts if in debug mode, or single stepping without dcsr.stepie set.
   assign debug_interruptible = !(debug_mode_q || (dcsr_i.step && !dcsr_i.stepie));

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -1101,6 +1101,7 @@ module cv32e40s_core import cv32e40s_pkg::*;
     // From CSR registers
     .mtvec_mode_i                   ( mtvec_mode             ),
     .mcause_i                       ( mcause                 ),
+    .xsecure_ctrl_i                 ( xsecure_ctrl           ),
 
     // Trigger module
     .etrigger_wb_i                  ( etrigger_wb            ),

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -321,6 +321,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
     .jvt_addr_i        ( jvt_addr_i                        ),
     .jvt_index_i       ( jvt_index                         ),
     .compressed_i      ( if_id_pipe_i.instr_meta.compressed),
+    .dummy_i           ( if_id_pipe_i.instr_meta.dummy     ),
     .bch_target_o      ( bch_target                        ),
     .jmp_target_o      ( jmp_target_o                      ),
     .pc_next_o         ( pc_next                           )
@@ -732,10 +733,11 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
       assign jmp_bch_insn = ((alu_jmp || alu_bch) && alu_en) || (sys_mret_insn && sys_en);
 
       // Detect last operation of current instruction.
-      assign last_sec_op = jmp_bch_insn ? (multi_op_cnt == JMP_BCH_CYCLES - 1)
-                                    : 1'b1;
+      // Only when pc_hardening is enabled, otherwise no instruction will be split for pc_hardening.
+      assign last_sec_op = (jmp_bch_insn && xsecure_ctrl_i.cpuctrl.pc_hardening) ? (multi_op_cnt == JMP_BCH_CYCLES - 1)
+                                                                                 : 1'b1;
 
-      assign first_sec_op = jmp_bch_insn ? (multi_op_cnt == '0) : 1'b1;
+      assign first_sec_op = (jmp_bch_insn && xsecure_ctrl_i.cpuctrl.pc_hardening) ? (multi_op_cnt == '0) : 1'b1;
 
       // Count number of operations performed by an instruction.
       always_ff @(posedge clk, negedge rst_n) begin

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -351,6 +351,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .clk                  ( clk                  ),
     .rst_n                ( rst_n                ),
 
+    .xsecure_ctrl_i       ( xsecure_ctrl_i       ),
     .if_valid_i           ( if_valid_o           ),
     .id_ready_i           ( id_ready_i           ),
 

--- a/rtl/cv32e40s_pc_check.sv
+++ b/rtl/cv32e40s_pc_check.sv
@@ -35,6 +35,7 @@ module cv32e40s_pc_check import cv32e40s_pkg::*;
   input  logic        clk,
   input  logic        rst_n,
 
+  input xsecure_ctrl_t  xsecure_ctrl_i,
   input  logic        if_valid_i,
   input  logic        id_ready_i,
   input  logic        id_valid_i,
@@ -77,6 +78,8 @@ logic    jmp_taken_q;     // A jump was taken. Sticky until last part of instruc
 logic    bch_taken_q;     // A branch was taken. Sticky until last part of instruction is done
 pc_mux_e pc_mux_q;        // Last value of pc_mux (for address comparison)
 
+logic    enable;          // cpuctrl.pc_hardening
+logic    enable_q;        // 1 cycle delayed enable, used to disable checking the cycle after enable goes high.
 
 logic    compare_enable_q;
 
@@ -105,6 +108,7 @@ logic [31:0] nmi_addr;
 
 assign nmi_addr = {mtvec_addr_i, ctrl_fsm_i.nmi_mtvec_index, 2'b00};
 
+assign enable = xsecure_ctrl_i.cpuctrl.pc_hardening;
 
 //////////////////////////////////////////
 // PC checking
@@ -140,7 +144,8 @@ assign check_addr = !pc_set_q ? incr_addr : {ctrl_flow_addr[31:1], 1'b0};
 // Comparator for address
 // Comparison is only valid the cycle after pc_set or the cycle
 // after an instruction goes from IF to ID.
-assign addr_err = (pc_set_q || if_id_q) ? (check_addr != pc_if_i)  : 1'b0;
+assign addr_err = !enable ? 1'b0 :
+                  (pc_set_q || if_id_q) ? (check_addr != pc_if_i)  : 1'b0;
 
 //////////////////////////////////
 // Decision check
@@ -154,16 +159,19 @@ assign addr_err = (pc_set_q || if_id_q) ? (check_addr != pc_if_i)  : 1'b0;
 // control signals shall still be present in the pipeline stages.
 // Not factoring in last_sec_op_* signals, as this would cause the checks to fail if a jump or branch
 // was stalled such that the taken flags would be set while the first half was still in ID or EX.
-assign jump_mret_taken_err   = jmp_taken_q && !(ctrl_fsm_i.jump_in_id_raw);
-assign branch_taken_err      = bch_taken_q && !(ctrl_fsm_i.branch_in_ex_raw && branch_decision_ex_i);
+// When cpuctrl.pc_hardening is written, the controller will flush the pipeline the cycle after the CSR write
+// finished in WB. When the flush happens, the pipeline may contain conditions that lead to errors. Thus disregarding
+// the first enable cycle by using both enable and enable_q.
+assign jump_mret_taken_err   = (enable_q && enable) && (jmp_taken_q && !(ctrl_fsm_i.jump_in_id_raw));
+assign branch_taken_err      = (enable_q && enable) && (bch_taken_q && !(ctrl_fsm_i.branch_in_ex_raw && branch_decision_ex_i));
 
 // Check if jumps or branches should have been taken when the controller did not take them.
 // Since jumps and branches shall be taken during the first operation of the instruction,
 // we cannot observe an untaken jump/branch (*_taken_q is not set) and at the same time have a valid
 // jump or branch instruction with the last_sec_op bit set. Qualifying with registered instr_valid to make sure
 // the instruction was not killed earlier, which would cause the jump or branch to correctly be not taken.
-assign jump_mret_untaken_err = !jmp_taken_q && (ctrl_fsm_i.jump_in_id_raw   && if_id_pipe_i.instr_valid && last_sec_op_id_i);
-assign branch_untaken_err    = !bch_taken_q && (ctrl_fsm_i.branch_in_ex_raw && id_ex_pipe_i.instr_valid && last_op_ex_i && branch_decision_ex_i);
+assign jump_mret_untaken_err = (enable_q && enable) && (!jmp_taken_q && (ctrl_fsm_i.jump_in_id_raw   && if_id_pipe_i.instr_valid && last_sec_op_id_i));
+assign branch_untaken_err    = (enable_q && enable) && (!bch_taken_q && (ctrl_fsm_i.branch_in_ex_raw && id_ex_pipe_i.instr_valid && last_op_ex_i && branch_decision_ex_i));
 
 
 assign ctrl_flow_taken_err = jump_mret_taken_err || branch_taken_err;
@@ -186,6 +194,7 @@ always_ff @(posedge clk, negedge rst_n) begin
     if_id_q          <= 1'b0;
     jmp_taken_q      <= 1'b0;
     bch_taken_q      <= 1'b0;
+    enable_q         <= 1'b0;
   end else begin
     // Signal that a pc_set set was performed.
     // Exclude cases of PC_WB_PLUS4, PC_TRAP_IRQ and CLIC pointers as the pipeline currently has no easy way to recompute these targets.
@@ -233,6 +242,8 @@ always_ff @(posedge clk, negedge rst_n) begin
       pc_mux_q <= ctrl_fsm_i.pc_mux;
       compare_enable_q <= 1'b1;
     end
+
+    enable_q <= enable;
   end
 end
 

--- a/rtl/cv32e40s_pc_target.sv
+++ b/rtl/cv32e40s_pc_target.sv
@@ -34,6 +34,7 @@ module cv32e40s_pc_target import cv32e40s_pkg::*;
    input  logic [JVT_ADDR_WIDTH-1:0]  jvt_addr_i,
    input  logic [7:0]                 jvt_index_i,
    input  logic                       compressed_i,
+   input  logic                       dummy_i,
    output logic [31:0]                bch_target_o,
    output logic [31:0]                jmp_target_o,
    output logic [31:0]                pc_next_o
@@ -43,7 +44,7 @@ module cv32e40s_pc_target import cv32e40s_pkg::*;
 
   assign bch_target_o = pc_target;
   assign jmp_target_o = pc_target; // Used for both regular jumps and tablejumps
-  assign pc_next_o    = pc_id_i + (compressed_i ? 32'd2 : 32'd4);
+  assign pc_next_o    = pc_id_i + (dummy_i ? 32'd0 : compressed_i ? 32'd2 : 32'd4);
 
   always_comb begin : pc_target_mux
     unique case (bch_jmp_mux_sel_i)


### PR DESCRIPTION
Implemented turning pc_hardening on and off by using cpuctrl.pc_hardening.

Includes the following bugfixes:
- For a pipeline flush due to CSR writes, the controller could kill the pipeline for debug or interrupts before the flush was completed.
- The id_ex_pipe.pc_next was wrong for dummy branches (should have been +0 instead of +4)

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>