### PR TITLE
Merge from CV32E40X

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -73,7 +73,9 @@ module cv32e40s_wrapper
   parameter lfsr_cfg_t   LFSR0_CFG                    = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
   parameter lfsr_cfg_t   LFSR1_CFG                    = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
   parameter lfsr_cfg_t   LFSR2_CFG                    = LFSR_CFG_DEFAULT, // Do not use default value for LFSR configuration
-  parameter bit          CORE_LOG_ENABLE              = 1
+  parameter bit          CORE_LOG_ENABLE              = 1,
+  parameter logic [31:0] DM_REGION_START              = 32'hF0000000,
+  parameter logic [31:0] DM_REGION_END                = 32'hF0003FFF
 )
 (
   // Clock and Reset
@@ -442,13 +444,19 @@ endgenerate
         .PMP_GRANULARITY                        (PMP_GRANULARITY),
         .PMA_NUM_REGIONS                        (PMA_NUM_REGIONS),
         .PMA_CFG                                (PMA_CFG),
-        .IS_INSTR_SIDE                          (1))
+        .IS_INSTR_SIDE                          (1),
+        .CORE_RESP_TYPE                         (cv32e40s_pkg::inst_resp_t),
+        .CORE_REQ_TYPE                          (cv32e40s_pkg::obi_inst_req_t),
+        .DM_REGION_START                        (DM_REGION_START),
+        .DM_REGION_END                          (DM_REGION_END))
   mpu_if_sva(.pma_addr                          (pma_i.trans_addr_i),
              .pma_cfg                           (pma_i.pma_cfg),
+             .pma_dbg                           (core_i.if_stage_i.mpu_i.core_trans_i.dbg),
              .obi_memtype                       (core_i.instr_memtype_o),
              .obi_addr                          (core_i.instr_addr_o),
              .obi_req                           (core_i.instr_req_o),
              .obi_gnt                           (core_i.instr_gnt_i),
+             .obi_dbg                           (core_i.instr_dbg_o),
              .write_buffer_state                (cv32e40s_pkg::WBUF_EMPTY),
              .write_buffer_valid_o              ('0),
              .write_buffer_txn_bufferable       ('0),
@@ -464,18 +472,23 @@ endgenerate
         .PMA_CFG                                (PMA_CFG),
         .IS_INSTR_SIDE                          (0),
         .CORE_RESP_TYPE                         (cv32e40s_pkg::data_resp_t),
-        .X_EXT                                  (X_EXT))
+        .CORE_REQ_TYPE                          (cv32e40s_pkg::obi_data_req_t),
+        .X_EXT                                  (X_EXT),
+        .DM_REGION_START                        (DM_REGION_START),
+        .DM_REGION_END                          (DM_REGION_END))
   mpu_lsu_sva(.pma_addr                         (pma_i.trans_addr_i),
-              .pma_cfg                          (pma_i.pma_cfg),
-              .obi_memtype                      (core_i.data_memtype_o),
-              .obi_addr                         (core_i.data_addr_o),
-              .obi_req                          (core_i.data_req_o),
-              .obi_gnt                          (core_i.data_gnt_i),
-              .write_buffer_state               (core_i.load_store_unit_i.write_buffer_i.state),
-              .write_buffer_valid_o             (core_i.load_store_unit_i.write_buffer_i.valid_o),
-              .write_buffer_txn_bufferable      (core_i.load_store_unit_i.write_buffer_i.trans_o.memtype[0]),
-              .write_buffer_txn_cacheable       (core_i.load_store_unit_i.write_buffer_i.trans_o.memtype[1]),
-              .*);
+             .pma_cfg                           (pma_i.pma_cfg),
+             .pma_dbg                           (core_i.load_store_unit_i.mpu_i.core_trans_i.dbg),
+             .obi_memtype                       (core_i.data_memtype_o),
+             .obi_addr                          (core_i.data_addr_o),
+             .obi_req                           (core_i.data_req_o),
+             .obi_gnt                           (core_i.data_gnt_i),
+             .obi_dbg                           (core_i.data_dbg_o),
+             .write_buffer_state                (core_i.load_store_unit_i.write_buffer_i.state),
+             .write_buffer_valid_o              (core_i.load_store_unit_i.write_buffer_i.valid_o),
+             .write_buffer_txn_bufferable       (core_i.load_store_unit_i.write_buffer_i.trans_o.memtype[0]),
+             .write_buffer_txn_cacheable        (core_i.load_store_unit_i.write_buffer_i.trans_o.memtype[1]),
+             .*);
 
   bind cv32e40s_lsu_response_filter :
     core_i.load_store_unit_i.response_filter_i
@@ -825,6 +838,8 @@ endgenerate
           .SMCLIC                ( SMCLIC                ),
           .SMCLIC_ID_WIDTH       ( SMCLIC_ID_WIDTH       ),
           .SMCLIC_INTTHRESHBITS  ( SMCLIC_INTTHRESHBITS  ),
+          .DM_REGION_START       ( DM_REGION_START       ),
+          .DM_REGION_END         ( DM_REGION_END         ),
           .DBG_NUM_TRIGGERS      ( DBG_NUM_TRIGGERS      ),
           .PMA_NUM_REGIONS       ( PMA_NUM_REGIONS       ),
           .PMA_CFG               ( PMA_CFG               ),

--- a/docs/user_manual/source/exceptions_interrupts.rst
+++ b/docs/user_manual/source/exceptions_interrupts.rst
@@ -71,7 +71,8 @@ Non Maskable Interrupts (NMIs) update ``mepc``, ``mcause`` and ``mstatus`` simil
 
 .. note::
 
-   Specifically ``mstatus.mie`` will get cleared to 0 when an (unrecoverable) NMI is taken. [RISC-V-PRIV]_ does not specify the behavior of
+   (Unrecoverable) NMIs and regular interrupts have identical effects on the ``mstatus`` CSR". Specifically ``mstatus.mie`` will get cleared
+   to 0 when an (unrecoverable) NMI is taken. [RISC-V-PRIV]_ does not specify the behavior of
    ``mstatus`` in response to NMIs, see https://github.com/riscv/riscv-isa-manual/issues/756. If this behavior is
    specified at a future date, then we will reconsider our implementation.
 
@@ -229,8 +230,8 @@ In Debug Mode, all interrupts are ignored independent of ``mstatus.MIE`` and the
 
 .. note::
 
-   The NMI vector location is at index 15 of the machine trap vector table for both non-vectored CLINT mode and vectored CLINT mode (i.e. at {**mtvec[31:7]**, 5'hF, 2'b00}).
-   The NMI vector location therefore does **not** match its exception code.
+   The NMI vector location is at index 15 of the machine trap vector table for vectored CLINT mode (i.e. at {**mtvec[31:7]**, 5'hF, 2'b00}).
+   The NMI vector location therefore does **not** match its exception code as is otherwise the case for vectored CLINT mode.
 
 Nested Interrupt Handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -35,6 +35,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
   parameter rv32_e                      RV32                                    = RV32I,
   parameter b_ext_e                     B_EXT                                   = B_NONE,
   parameter m_ext_e                     M_EXT                                   = M,
+  parameter logic [31:0]                DM_REGION_START                         = 32'hF0000000,
+  parameter logic [31:0]                DM_REGION_END                           = 32'hF0003FFF,
   parameter int                         DBG_NUM_TRIGGERS                        = 1,
   parameter int                         PMA_NUM_REGIONS                         = 0,
   parameter pma_cfg_t                   PMA_CFG[PMA_NUM_REGIONS-1:0]            = '{default:PMA_R_DEFAULT},
@@ -543,7 +545,9 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .SMCLIC              ( SMCLIC                   ),
     .SMCLIC_ID_WIDTH     ( SMCLIC_ID_WIDTH          ),
     .ZC_EXT              ( ZC_EXT                   ),
-    .M_EXT               ( M_EXT                    )
+    .M_EXT               ( M_EXT                    ),
+    .DM_REGION_START     ( DM_REGION_START          ),
+    .DM_REGION_END       ( DM_REGION_END            )
   )
   if_stage_i
   (
@@ -768,13 +772,15 @@ module cv32e40s_core import cv32e40s_pkg::*;
   ////////////////////////////////////////////////////////////////////////////////////////
 
   cv32e40s_load_store_unit
-    #(.X_EXT                 (X_EXT           ),
-      .X_ID_WIDTH            (X_ID_WIDTH      ),
-      .PMP_GRANULARITY       (PMP_GRANULARITY ),
-      .PMP_NUM_REGIONS       (PMP_NUM_REGIONS ),
-      .PMA_NUM_REGIONS       (PMA_NUM_REGIONS ),
-      .PMA_CFG               (PMA_CFG         ),
-      .DBG_NUM_TRIGGERS      (DBG_NUM_TRIGGERS))
+    #(.X_EXT                 (X_EXT             ),
+      .X_ID_WIDTH            (X_ID_WIDTH        ),
+      .PMP_GRANULARITY       (PMP_GRANULARITY   ),
+      .PMP_NUM_REGIONS       (PMP_NUM_REGIONS   ),
+      .PMA_NUM_REGIONS       (PMA_NUM_REGIONS   ),
+      .PMA_CFG               (PMA_CFG           ),
+      .DBG_NUM_TRIGGERS      (DBG_NUM_TRIGGERS  ),
+      .DM_REGION_START       (DM_REGION_START   ),
+      .DM_REGION_END         (DM_REGION_END     ))
   load_store_unit_i
   (
     .clk                   ( clk                ),

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -41,7 +41,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   parameter bit          SMCLIC          = 1'b0,
   parameter int          SMCLIC_ID_WIDTH = 5,
   parameter bit          ZC_EXT          = 0,
-  parameter m_ext_e      M_EXT           = M_NONE
+  parameter m_ext_e      M_EXT           = M_NONE,
+  parameter logic [31:0] DM_REGION_START = 32'hF0000000,
+  parameter logic [31:0] DM_REGION_END   = 32'hF0003FFF
 )
 (
   input  logic          clk,
@@ -286,7 +288,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .PMA_NUM_REGIONS      ( PMA_NUM_REGIONS         ),
     .PMA_CFG              ( PMA_CFG                 ),
     .PMP_GRANULARITY      ( PMP_GRANULARITY         ),
-    .PMP_NUM_REGIONS      ( PMP_NUM_REGIONS         )
+    .PMP_NUM_REGIONS      ( PMP_NUM_REGIONS         ),
+    .DM_REGION_START      ( DM_REGION_START         ),
+    .DM_REGION_END        ( DM_REGION_END           )
   )
   mpu_i
   (

--- a/rtl/cv32e40s_load_store_unit.sv
+++ b/rtl/cv32e40s_load_store_unit.sv
@@ -32,7 +32,9 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
     parameter int          PMP_NUM_REGIONS = 0,
     parameter int          PMA_NUM_REGIONS = 0,
     parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
-    parameter int          DBG_NUM_TRIGGERS = 1)
+    parameter int          DBG_NUM_TRIGGERS = 1,
+    parameter logic [31:0] DM_REGION_START = 32'hF0000000,
+    parameter logic [31:0] DM_REGION_END   = 32'hF0003FFF)
 (
   input  logic        clk,
   input  logic        rst_n,
@@ -741,7 +743,9 @@ module cv32e40s_load_store_unit import cv32e40s_pkg::*;
     .PMA_NUM_REGIONS    ( PMA_NUM_REGIONS      ),
     .PMA_CFG            ( PMA_CFG              ),
     .PMP_GRANULARITY    ( PMP_GRANULARITY      ),
-    .PMP_NUM_REGIONS    ( PMP_NUM_REGIONS      )
+    .PMP_NUM_REGIONS    ( PMP_NUM_REGIONS      ),
+    .DM_REGION_START    ( DM_REGION_START      ),
+    .DM_REGION_END      ( DM_REGION_END        )
   )
   mpu_i
   (

--- a/rtl/cv32e40s_pma.sv
+++ b/rtl/cv32e40s_pma.sv
@@ -1,13 +1,13 @@
 // Copyright 2021 Silicon Labs, Inc.
-//   
+//
 // This file, and derivatives thereof are licensed under the
 // Solderpad License, Version 2.0 (the "License");
 // Use of this file means you agree to the terms and conditions
 // of the license and are in full compliance with the License.
 // You may obtain a copy of the License at
-//   
+//
 //     https://solderpad.org/licenses/SHL-2.0/
-//   
+//
 // Unless required by applicable law or agreed to in writing, software
 // and hardware implementations thereof
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,12 +24,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 module cv32e40s_pma import cv32e40s_pkg::*;
-#(  
+#(
   parameter int          PMA_NUM_REGIONS = 0,
   parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT}
 )
 (
   input  logic [31:0] trans_addr_i,
+  input  logic        trans_debug_region_i, // Transaction address is inside the debug region
   input  logic        instr_fetch_access_i, // Indicate that ongoing access is an instruction fetch
   input  logic        misaligned_access_i,  // Indicate that ongoing access is part of a misaligned access
   input  logic        load_access_i,        // Indicate that ongoing access is a load
@@ -38,9 +39,18 @@ module cv32e40s_pma import cv32e40s_pkg::*;
   output logic        pma_bufferable_o,
   output logic        pma_cacheable_o
 );
-  
+
   parameter PMA_ADDR_LSB = 0; // TODO:OE experiment and see if this makes a difference
-  
+
+  // Attributes for accessing the DM (DM_REGION_START:DM_REGION_END) in debug mode
+  localparam pma_cfg_t PMA_DBG = '{word_addr_low   : '0, // not used
+                                   word_addr_high  : '0, // not used
+                                   main            : 1'b1,
+                                   bufferable      : 1'b0,
+                                   cacheable       : 1'b0,
+                                   integrity       : 1'b0};
+
+
   pma_cfg_t pma_cfg;
   logic [31:0] word_addr;
 
@@ -50,8 +60,15 @@ module cv32e40s_pma import cv32e40s_pkg::*;
   generate
     if(PMA_NUM_REGIONS == 0) begin: no_pma
 
-      // PMA is deconfigured
-      assign pma_cfg = NO_PMA_R_DEFAULT;
+      always_comb begin
+        // PMA is deconfigured, use NO_PMA_R_DEFAULT as default.
+        pma_cfg = NO_PMA_R_DEFAULT;
+
+        // Debug mode transactions within the Debug Module region use PMA_DBG as attributes for the DM range
+        if (trans_debug_region_i) begin
+          pma_cfg = PMA_DBG;
+        end
+      end
 
     end
     else begin: pma
@@ -59,14 +76,19 @@ module cv32e40s_pma import cv32e40s_pkg::*;
       // Identify PMA region
       always_comb begin
 
-        // If no match, use default PMA config
+        // If no match, use default PMA config as default.
         pma_cfg = PMA_R_DEFAULT;
 
         for(int i = PMA_NUM_REGIONS-1; i >= 0; i--)  begin
-          if((word_addr[31:PMA_ADDR_LSB] >= PMA_CFG[i].word_addr_low[31:PMA_ADDR_LSB]) && 
+          if((word_addr[31:PMA_ADDR_LSB] >= PMA_CFG[i].word_addr_low[31:PMA_ADDR_LSB]) &&
              (word_addr[31:PMA_ADDR_LSB] <  PMA_CFG[i].word_addr_high[31:PMA_ADDR_LSB])) begin
             pma_cfg = PMA_CFG[i];
           end
+        end
+
+        // Debug mode transactions within the Debug Module region use PMA_DBG as attributes for the DM range
+        if (trans_debug_region_i) begin
+          pma_cfg = PMA_DBG;
         end
       end
     end
@@ -75,7 +97,7 @@ module cv32e40s_pma import cv32e40s_pkg::*;
 
   // Check transaction based on PMA region config
   always_comb begin
-    
+
     pma_err_o = 1'b0;
 
     // Instruction fetches only allowed in main memory
@@ -96,5 +118,5 @@ module cv32e40s_pma import cv32e40s_pkg::*;
   // Instruction fetches and loads are never classified as bufferable
   assign pma_bufferable_o = pma_cfg.bufferable && !instr_fetch_access_i && !load_access_i;
   assign pma_cacheable_o  = pma_cfg.cacheable;
-  
+
 endmodule

--- a/sva/cv32e40s_mpu_sva.sv
+++ b/sva/cv32e40s_mpu_sva.sv
@@ -31,7 +31,10 @@ module cv32e40s_mpu_sva import cv32e40s_pkg::*; import uvm_pkg::*;
       parameter pma_cfg_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
       parameter int unsigned IS_INSTR_SIDE = 0,
       parameter type         CORE_RESP_TYPE = inst_resp_t,
-      parameter bit          X_EXT = 1'b0)
+      parameter type         CORE_REQ_TYPE  = obi_inst_req_t,
+      parameter bit          X_EXT = 1'b0,
+      parameter logic [31:0] DM_REGION_START = 32'hF0000000,
+      parameter logic [31:0] DM_REGION_END   = 32'hF0003FFF)
   (
    input logic        clk,
    input logic        rst_n,
@@ -40,11 +43,13 @@ module cv32e40s_mpu_sva import cv32e40s_pkg::*; import uvm_pkg::*;
    input logic        misaligned_access_i,
    input logic        bus_trans_bufferable,
    input logic        bus_trans_cacheable,
+   input logic        bus_trans_integrity,
 
    // PMA signals
    input logic        pma_err,
    input logic [31:0] pma_addr,
    input pma_cfg_t    pma_cfg,
+   input logic        pma_dbg,
 
    // PMP signals
    input pmp_csr_t    csr_pmp_i,
@@ -54,6 +59,7 @@ module cv32e40s_mpu_sva import cv32e40s_pkg::*; import uvm_pkg::*;
    input logic [31:0] obi_addr,
    input logic        obi_req,
    input logic        obi_gnt,
+   input logic        obi_dbg,
 
    // Interface towards bus interface
    input logic        bus_trans_ready_i,
@@ -68,8 +74,9 @@ module cv32e40s_mpu_sva import cv32e40s_pkg::*; import uvm_pkg::*;
    input logic        write_buffer_txn_cacheable,
 
    // Interface towards core
-   input logic        core_trans_valid_i,
-   input logic        core_trans_ready_o,
+   input logic         core_trans_valid_i,
+   input logic         core_trans_ready_o,
+   input CORE_REQ_TYPE core_trans_i,
 
    input logic          core_resp_valid_o,
    input logic          core_resp_ready_i,
@@ -90,6 +97,11 @@ module cv32e40s_mpu_sva import cv32e40s_pkg::*; import uvm_pkg::*;
   // Not checking bits [1:0]; bit 0 is always 0; bit 1 is not checked because it is only
   // suppressed after the PMA. These address bits are also ignored by the PMA itself.
   assign is_addr_match = obi_addr[31:2] == pma_addr[31:2];
+
+  // Check if a transaction matches DM_REGION while in debug mode
+  logic is_pma_dbg_matched;
+
+  assign is_pma_dbg_matched = (core_trans_i.addr >= DM_REGION_START && core_trans_i.addr <= DM_REGION_END) && core_trans_i.dbg;
 
   logic was_obi_waiting;
   logic was_obi_reqnognt;
@@ -217,7 +229,9 @@ module cv32e40s_mpu_sva import cv32e40s_pkg::*; import uvm_pkg::*;
   always_comb begin
     pma_expected_cfg = NO_PMA_R_DEFAULT;
     if (PMA_NUM_REGIONS) begin
-      pma_expected_cfg = is_pma_matched ? PMA_CFG[pma_lowest_match] : PMA_R_DEFAULT;
+      pma_expected_cfg = is_pma_dbg_matched ? '{main    : 1'b1, default : '0} :
+                         is_pma_matched     ? PMA_CFG[pma_lowest_match]       : PMA_R_DEFAULT;
+
     end
   end
   assign pma_expected_err = (instr_fetch_access && !pma_expected_cfg.main)  ||
@@ -299,9 +313,16 @@ module cv32e40s_mpu_sva import cv32e40s_pkg::*; import uvm_pkg::*;
     assert property (@(posedge clk) disable iff (!rst_n)
                      obi_req
                      |->
+                     // If we have an address match, there must be no PMA error
                      (!pma_err && is_addr_match) ||
+                     // or a transaction from the write buffer is causing obi_req
+                     // (a different transaction could cause pma_err in the same cycle)
                      (write_buffer_state && write_buffer_valid_o) ||
-                     (!is_addr_match && was_obi_waiting && $past(obi_req)))
+                     // or we are already outputting a obi_req but a new address comes in which may cause a pma_err
+                     (!is_addr_match && was_obi_waiting && $past(obi_req)) ||
+                     // or we get an address match, but was already outputting the same address (no pma_err)
+                     // but a change in debug mode causes the new transaction the same address to fail
+                     (is_addr_match && was_obi_waiting && $past(obi_req) && (!pma_dbg && obi_dbg)))
       else `uvm_error("mpu", "obi made request to pma-forbidden region")
 
   generate
@@ -491,6 +512,20 @@ if (!IS_INSTR_SIDE ) begin
       else `uvm_error("mpu", "Downstream stage not ready to receive response")
   end
 end
+
+  // Check that PMA sets correct attribution for accesses to DM during debug
+  // main, non-cacheable, non-bufferable, non-integrity
+
+  a_dm_region_dbg:
+  assert property (@(posedge clk) disable iff (!rst_n)
+                  is_pma_dbg_matched
+                  |->
+                  !pma_err &&               // Always 'main' while accessing DM in debug mode
+                  !bus_trans_cacheable &&
+                  !bus_trans_bufferable &&
+                  !bus_trans_integrity)
+        else `uvm_error("mpu", "Wrong attributes for access to DM during debug mode")
+
 
 endmodule : cv32e40s_mpu_sva
 


### PR DESCRIPTION
Includes support for DM_REGION.
Note that after this merge, there will still be a bug related to the recently introduced wpt/mpu backpressure. A fix for that is in progress on cv32e40x and will be merge to cv32e40s as soon as it is finished.