### PR TITLE
Fix for issue #394.

### DIFF
--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -2096,7 +2096,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     if (SECURE) begin : xsecure
 
       logic [2:0] lfsr_lockup;
-      logic       lfsr_en;
 
       cv32e40s_csr
       #(
@@ -2117,7 +2116,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rd_error_o     ( cpuctrl_rd_error      )
       );
 
-      assign lfsr_en = cpuctrl_q.rnddummy || cpuctrl_q.rndhint;
 
       // Shifting LFSR0 in IF because it controls instruction insertion
       cv32e40s_lfsr
@@ -2130,7 +2128,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rst_n          ( rst_n                 ),
         .seed_i         ( csr_wdata_int         ),      // Direct use of csr_wdata_int (secureseed0_n = 0 used by RVFI; resolution on read)
         .seed_we_i      ( secureseed0_we        ),
-        .enable_i       ( lfsr_en               ),
         .shift_i        ( lfsr_shift_if_i       ),
         .data_o         ( xsecure_ctrl_o.lfsr0  ),
         .lockup_o       ( lfsr_lockup[0]        )
@@ -2147,7 +2144,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rst_n          ( rst_n                 ),
         .seed_i         ( csr_wdata_int         ),      // Direct use of csr_wdata_int (secureseed1_n = 0 used by RVFI; resolution on read)
         .seed_we_i      ( secureseed1_we        ),
-        .enable_i       ( lfsr_en               ),
         .shift_i        ( lfsr_shift_id_i       ),
         .data_o         ( xsecure_ctrl_o.lfsr1  ),
         .lockup_o       ( lfsr_lockup[1]        )
@@ -2163,7 +2159,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .rst_n          ( rst_n                 ),
         .seed_i         ( csr_wdata_int         ),      // Direct use of csr_wdata_int (secureseed2_n = 0 used by RVFI; resolution on read)
         .seed_we_i      ( secureseed2_we        ),
-        .enable_i       ( lfsr_en               ),
         .shift_i        ( lfsr_shift_id_i       ),
         .data_o         ( xsecure_ctrl_o.lfsr2  ),
         .lockup_o       ( lfsr_lockup[2]        )

--- a/rtl/cv32e40s_lfsr.sv
+++ b/rtl/cv32e40s_lfsr.sv
@@ -35,7 +35,6 @@ module cv32e40s_lfsr import cv32e40s_pkg::*;
   (input logic         clk,
    input logic         rst_n,
 
-   input logic         enable_i,
    input logic [31:0]  seed_i,
    input logic         seed_we_i,
    input logic         shift_i,
@@ -75,10 +74,10 @@ module cv32e40s_lfsr import cv32e40s_pkg::*;
   end
 
   // Detect lockup (all 0's with XOR based feedback) in next cycle due to shift
-  assign lockup_shift = !(|lfsr_n) && shift_i && !seed_we_i && enable_i;
+  assign lockup_shift = !(|lfsr_n) && shift_i && !seed_we_i;
 
   // Detect lockup (all 0's with XOR based feedback) in next cycle due to writes
-  assign lockup_wr = !(|seed_i) && seed_we_i && enable_i;
+  assign lockup_wr = !(|seed_i) && seed_we_i;
 
   assign lockup_o = lockup_shift || lockup_wr;
 


### PR DESCRIPTION
- Removed 'enable_i' from LFSR modules.
- It is no longer possible to write a locked up value to the LFSR, detection is now independent of the enabling of dummies or hint replacements.

Not SEC clean:
- Alert minor caused by writing a locked up value when dummies/hint replacements are disabled.
- Previously, a locked up value could be stored in the LFSR, resulting in a difference in which dummy or hint was generated on the first instruction after enabling.

Signed-off-by: Oystein Knauserud <Oystein.Knauserud@silabs.com>