### PR TITLE
Merge from CV32E40X

### DIFF
--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -22,7 +22,7 @@ module cv32e40s_rvfi
   import cv32e40s_pkg::*;
   import cv32e40s_rvfi_pkg::*;
   #(
-    parameter bit SMCLIC = 0,
+    parameter bit CLIC   = 0,
     parameter int DEBUG  = 1
   )
   (

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -64,9 +64,9 @@ module cv32e40s_wrapper
   parameter pmpncfg_t    PMP_PMPNCFG_RV[PMP_NUM_REGIONS-1:0] = '{default:PMPNCFG_DEFAULT},
   parameter [31:0]       PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
   parameter mseccfg_t    PMP_MSECCFG_RV                      = MSECCFG_DEFAULT,
-  parameter bit          SMCLIC                       = 0,
-  parameter int          SMCLIC_ID_WIDTH              = 5,
-  parameter int          SMCLIC_INTTHRESHBITS         = 8,
+  parameter bit          CLIC                         = 0,
+  parameter int          CLIC_ID_WIDTH                = 5,
+  parameter int          CLIC_INTTHRESHBITS           = 8,
   parameter int          DBG_NUM_TRIGGERS             = 1,
   parameter int          PMA_NUM_REGIONS              = 0,
   parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
@@ -139,7 +139,7 @@ module cv32e40s_wrapper
 
   // CLIC Interface
   input  logic                       clic_irq_i,
-  input  logic [SMCLIC_ID_WIDTH-1:0] clic_irq_id_i,
+  input  logic [CLIC_ID_WIDTH-1:0]   clic_irq_id_i,
   input  logic [ 7:0]                clic_irq_level_i,
   input  logic [ 1:0]                clic_irq_priv_i,
   input  logic                       clic_irq_shv_i,
@@ -262,7 +262,7 @@ module cv32e40s_wrapper
       cv32e40s_controller_fsm_sva
         #(.X_EXT(X_EXT),
           .DEBUG(DEBUG),
-          .SMCLIC(SMCLIC))
+          .CLIC(CLIC))
         controller_fsm_sva   (
                               .lsu_outstanding_cnt (core_i.load_store_unit_i.cnt_q),
                               .rf_we_wb_i          (core_i.wb_stage_i.rf_we_wb_o  ),
@@ -295,8 +295,7 @@ module cv32e40s_wrapper
   bind cv32e40s_cs_registers:
     core_i.cs_registers_i
       cv32e40s_cs_registers_sva
-        #(.SMCLIC(SMCLIC),
-        .PMP_ADDR_WIDTH (core_i.cs_registers_i.PMP_ADDR_WIDTH),
+        #(.CLIC  (CLIC),
           .DEBUG (DEBUG))
         cs_registers_sva (.wb_valid_i  (core_i.wb_valid                                 ),
                           .ctrl_fsm_cs (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
@@ -342,7 +341,7 @@ module cv32e40s_wrapper
   bind cv32e40s_prefetch_unit:
     core_i.if_stage_i.prefetch_unit_i
       cv32e40s_prefetch_unit_sva
-      #(.SMCLIC(SMCLIC))
+      #(.CLIC(CLIC))
       prefetch_unit_sva (
                           .ctrl_fsm_cs     (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
                           .debug_req_i     (core_i.debug_req_i),
@@ -363,7 +362,7 @@ module cv32e40s_wrapper
   bind cv32e40s_prefetcher:
     core_i.if_stage_i.prefetch_unit_i.prefetcher_i
       cv32e40s_prefetcher_sva
-        #(.SMCLIC(SMCLIC))
+        #(.CLIC(CLIC))
         prefetcher_sva ( .prefetch_is_clic_ptr (core_i.if_stage_i.prefetch_unit_i.prefetch_is_clic_ptr_o),
                         .*);
 
@@ -371,7 +370,7 @@ module cv32e40s_wrapper
     core_i cv32e40s_core_sva
       #(.DEBUG (DEBUG),
         .PMA_NUM_REGIONS(PMA_NUM_REGIONS),
-        .SMCLIC(SMCLIC),
+        .CLIC(CLIC),
         .REGFILE_NUM_READ_PORTS(core_i.REGFILE_NUM_READ_PORTS))
       core_sva (// probed cs_registers signals
                 .cs_registers_mie_q               (core_i.cs_registers_i.mie_q),
@@ -415,7 +414,7 @@ module cv32e40s_wrapper
                 .mie_we                           (core_i.cs_registers_i.mie_we),
                 .*);
 generate
-if (SMCLIC) begin : clic_asserts
+if (CLIC) begin : clic_asserts
   bind cv32e40s_clic_int_controller:
     core_i.gen_clic_interrupt.clic_int_controller_i
       cv32e40s_clic_int_controller_sva
@@ -540,7 +539,7 @@ endgenerate
   bind cv32e40s_rvfi:
     rvfi_i
     cv32e40s_rvfi_sva
-      #(.SMCLIC(SMCLIC),
+      #(.CLIC  (CLIC ),
         .DEBUG (DEBUG))
       rvfi_sva(.irq_ack(core_i.irq_ack),
                .dbg_ack(core_i.dbg_ack),
@@ -563,7 +562,7 @@ endgenerate
       );
 
     cv32e40s_rvfi
-      #(.SMCLIC(SMCLIC),
+      #(.CLIC  (CLIC  ),
         .DEBUG (DEBUG))
       rvfi_i
         (.clk_i                    ( clk_i                                                                ),
@@ -842,9 +841,9 @@ endgenerate
           .PMP_PMPNCFG_RV        ( PMP_PMPNCFG_RV        ),
           .PMP_PMPADDR_RV        ( PMP_PMPADDR_RV        ),
           .PMP_MSECCFG_RV        ( PMP_MSECCFG_RV        ),
-          .SMCLIC                ( SMCLIC                ),
-          .SMCLIC_ID_WIDTH       ( SMCLIC_ID_WIDTH       ),
-          .SMCLIC_INTTHRESHBITS  ( SMCLIC_INTTHRESHBITS  ),
+          .CLIC                  ( CLIC                  ),
+          .CLIC_ID_WIDTH         ( CLIC_ID_WIDTH         ),
+          .CLIC_INTTHRESHBITS    ( CLIC_INTTHRESHBITS    ),
           .DEBUG                 ( DEBUG                 ),
           .DM_REGION_START       ( DM_REGION_START       ),
           .DM_REGION_END         ( DM_REGION_END         ),

--- a/docs/user_manual/source/exceptions_interrupts.rst
+++ b/docs/user_manual/source/exceptions_interrupts.rst
@@ -4,8 +4,8 @@ Exceptions and Interrupts
 =========================
 
 |corev| supports one of two interrupt architectures.
-If the ``SMCLIC`` parameter is set to 0, then the CLINT mode interrupt architecture is supported (see :ref:`clint_interrupt_architecture`).
-If the ``SMCLIC`` parameter is set to 1, then the CLIC mode interrupt architecture is supported (see :ref:`clic_interrupt_architecture`).
+If the ``CLIC`` parameter is set to 0, then the CLINT mode interrupt architecture is supported (see :ref:`clint_interrupt_architecture`).
+If the ``CLIC`` parameter is set to 1, then the CLIC mode interrupt architecture is supported (see :ref:`clic_interrupt_architecture`).
 
 Exceptions
 ----------
@@ -78,12 +78,12 @@ Non Maskable Interrupts (NMIs) update ``mepc``, ``mcause`` and ``mstatus`` simil
 
 NMIs have higher priority than other interrupts for both the CLINT mode interrupt architecture and the CLIC mode interrupt architecture.
 
-If ``SMCLIC`` == 0, then the NMI vector location is as follows:
+If ``CLIC`` == 0, then the NMI vector location is as follows:
 
 * Upon an NMI in non-vectored CLINT mode the core jumps to **mtvec[31:7]**, 5'h0, 2'b00} (i.e. index 0).
 * Upon an NMI in vectored CLINT mode the core jumps to **mtvec[31:7]**, 5'hF, 2'b00} (i.e. index 15).
 
-If ``SMCLIC`` == 1, then the NMI vector location is as follows:
+If ``CLIC`` == 1, then the NMI vector location is as follows:
 
 * Upon an NMI in CLIC mode the core jumps to **mtvec[31:7]**, 5'h0, 2'b00} (i.e. index 0).
 
@@ -109,7 +109,7 @@ While an NMI is pending, ``DCSR.nmip`` will be 1. Note that this CSR is only acc
 CLINT Mode Interrupt Architecture
 ---------------------------------
 
-If ``SMCLIC`` == 0, then |corev| supports the CLINT mode interrupt architecture as defined in [RISC-V-PRIV]_. In this configuration only the
+If ``CLIC`` == 0, then |corev| supports the CLINT mode interrupt architecture as defined in [RISC-V-PRIV]_. In this configuration only the
 CLINT mode interrupt handling modes (non-vectored CLINT mode and vectored CLINT mode) can be used. The ``irq_i[31:16]`` interrupts are a custom extension
 that can be used with the CLINT mode interrupt architecture.
 
@@ -250,10 +250,10 @@ To allow higher priority interrupts only, the handler must configure ``mie`` acc
 CLIC Mode Interrupt Architecture
 --------------------------------
 
-If ``SMCLIC`` == 1, then |corev| supports the Core-Local Interrupt Controller (CLIC) Privileged Architecture Extension defined in [RISC-V-SMCLIC]_. In this
-configuration only the CLIC interrupt handling mode can be used (i.e. ``mtvec[1:0]`` = 0x3).
+If ``CLIC`` == 1, then |corev| supports the  Smclic, Smclicshv and Smclicconfig extensions defined in [RISC-V-CLIC]_. The Ssclic and Suclic extensions are not supported.
+In this configuration (i.e. ``CLIC`` == 1) only the CLIC interrupt handling mode can be used (i.e. ``mtvec[1:0]`` = 0x3).
 
-The CLIC implementation is split into a part internal to the core (containing CSRs and related logic) and a part external to the core (containing memory mapped registers and arbitration logic). |corev| only
+The CLIC implementation is however split into a part internal to the core (containing CSRs and related logic) and a part external to the core (containing memory mapped registers and arbitration logic). |corev| **only**
 provides the core internal part of CLIC. The external part can be added on the interface described in :ref:`clic-interrupt-interface`. CLIC provides low-latency, vectored, pre-emptive interrupts.
 
 .. _clic-interrupt-interface:
@@ -273,7 +273,7 @@ Interrupt Interface
   +========================================+===========+==================================================+
   | ``clic_irq_i``                         | input     | Is there any pending-and-enabled interrupt?      |
   +----------------------------------------+-----------+--------------------------------------------------+
-  | ``clic_irq_id_i[SMCLIC_ID_WIDTH-1:0]`` | input     | Index of the most urgent pending-and-enabled     |
+  | ``clic_irq_id_i[CLIC_ID_WIDTH-1:0]``   | input     | Index of the most urgent pending-and-enabled     |
   |                                        |           | interrupt.                                       |
   +----------------------------------------+-----------+--------------------------------------------------+
   | ``clic_irq_level_i[7:0]``              | input     | Interrupt level of the most urgent               |
@@ -288,7 +288,7 @@ Interrupt Interface
   +----------------------------------------+-----------+--------------------------------------------------+
 
 The term *pending-and-enabled* interrupt in above table refers to *pending-and-locally-enabled*, i.e. based on the ``CLICINTIP`` and
-``CLICINTIE`` memory mapped registers from [RISC-V-SMCLIC]_.
+``CLICINTIE`` memory mapped registers from [RISC-V-CLIC]_.
 
 .. note::
 
@@ -308,15 +308,15 @@ The term *pending-and-enabled* interrupt in above table refers to *pending-and-l
 
 Interrupts
 ~~~~~~~~~~
-Although the [RISC-V-SMCLIC]_ specification supports up to 4096 interrupts, |corev| itself supports at most 1024 interrupts. The
-maximum number of supported CLIC interrupts is equal to ``2^SMCLIC_ID_WIDTH``, which can range from 2 to 1024. The ``SMCLIC_ID_WIDTH`` parameter
+Although the [RISC-V-CLIC]_ specification supports up to 4096 interrupts, |corev| itself supports at most 1024 interrupts. The
+maximum number of supported CLIC interrupts is equal to ``2^CLIC_ID_WIDTH``, which can range from 2 to 1024. The ``CLIC_ID_WIDTH`` parameter
 also impacts the alignment requirement for the trap vector table, see :ref:`csr-mtvt`.
 
 Interrupt prioritization is mostly performed in the part of CLIC that is external to the core, with the exception that |corev| prioritizes all NMIs above interrupts received via ``clic_irq_i``.
 
 Nested Interrupt Handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-|corev| offers hardware support for nested interrupt handling when ``SMCLIC`` == 1.
+|corev| offers hardware support for nested interrupt handling when ``CLIC`` == 1.
 
 CLIC extends interrupt preemption to support up to 256 interrupt levels for each privilege mode,
-where higher-numbered interrupt levels can preempt lower-numbered interrupt levels. See [RISC-V-SMCLIC]_ for details.
+where higher-numbered interrupt levels can preempt lower-numbered interrupt levels. See [RISC-V-CLIC]_ for details.

--- a/docs/user_manual/source/integration.rst
+++ b/docs/user_manual/source/integration.rst
@@ -41,9 +41,9 @@ Instantiation Template
       .PMP_MSECCFG_RV           (   PMP_MSECCFG_RV ),
       .PMA_NUM_REGIONS          (                0 ),
       .PMA_CFG                  (        PMA_CFG[] ),
-      .SMCLIC                   (                0 ),
-      .SMCLIC_ID_WIDTH          (                5 ),
-      .SMCLIC_INTTHRESHBITS     (                8 ),
+      .CLIC                     (                0 ),
+      .CLIC_ID_WIDTH            (                5 ),
+      .CLIC_INTTHRESHBITS       (                8 ),
       .LFSR0_CFG                ( LFSR_CFG_DEFAULT ),
       .LFSR1_CFG                ( LFSR_CFG_DEFAULT ),
       .LFSR2_CFG                ( LFSR_CFG_DEFAULT )
@@ -182,14 +182,14 @@ Parameters
   +------------------------------+----------------+------------------+--------------------------------------------------------------------+
   | ``PMP_MSECCFG_RV``           | mseccfg_t      | 0                | Reset value for ``mseccfg`` CSR, see :ref:`pmp`                    |
   +------------------------------+----------------+------------------+--------------------------------------------------------------------+
-  | ``SMCLIC``                   | bit            | 0                | Is Smclic supported?                                               |
+  | ``CLIC``                     | bit            | 0                | Are Smclic, Smclicshv and Smclicconfig supported?                  |
   +------------------------------+----------------+------------------+--------------------------------------------------------------------+
-  | ``SMCLIC_ID_WIDTH``          | int (1..10 )   | 6                | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
+  | ``CLIC_ID_WIDTH``            | int (1..10 )   | 6                | Width of ``clic_irq_id_i`` and ``clic_irq_id_o``. The maximum      |
   |                              |                |                  | number of supported interrupts in CLIC mode is                     |
-  |                              |                |                  | ``2^SMCLIC_ID_WIDTH``. Trap vector table alignment is restricted   |
+  |                              |                |                  | ``2^CLIC_ID_WIDTH``. Trap vector table alignment is restricted     |
   |                              |                |                  | as described in :ref:`csr-mtvt`.                                   |
   +------------------------------+----------------+------------------+--------------------------------------------------------------------+
-  | ``SMCLIC_INTTHRESHBITS``     | int (1..8)     | 8                | Number of bits actually implemented in ``mintthresh.th`` field.    |
+  | ``CLIC_INTTHRESHBITS``       | int (1..8)     | 8                | Number of bits actually implemented in ``mintthresh.th`` field.    |
   +------------------------------+----------------+------------------+--------------------------------------------------------------------+
   | ``LFSR0``                    | lfsr_cfg_t     | LFSR_CFG_DEFAULT | LFSR0 configuration, see :ref:`xsecure`.                           |
   +------------------------------+----------------+------------------+--------------------------------------------------------------------+

--- a/docs/user_manual/source/intro.rst
+++ b/docs/user_manual/source/intro.rst
@@ -45,8 +45,8 @@ It follows these specifications:
 .. [RISC-V-DEBUG] RISC-V Debug Support, version 1.0-STABLE, 246028cd719426597269b3d717c866802c58bde7,
    https://github.com/riscv/riscv-debug-spec/blob/05252da1575610e9605d882145da3f4e7f4f3cb1/riscv-debug-stable.pdf
 
-.. [RISC-V-SMCLIC] "Smclic" Core-Local Interrupt Controller (CLIC) RISC-V Privileged Architecture Extension, version 0.9-draft, 11/08/2022,
-   https://github.com/riscv/riscv-fast-interrupt/blob/15618901f6e38e92919031eac99b980055353df6/clic.pdf
+.. [RISC-V-CLIC] Core-Local Interrupt Controller (CLIC) RISC-V Privileged Architecture Extensions, version 0.9-draft, 2/14/2023,
+   https://github.com/riscv/riscv-fast-interrupt/blob/a371ddda849a055932fa49fe58d1fee6d9063a3c/clic.pdf 
 
 .. [RISC-V-SMSTATEEN] RISC-V State Enable Extension, Smstateen, Version 0.6.3-70b1471, 2021-10-13: frozen,
    https://github.com/riscv/riscv-state-enable/releases/download/v0.6.3/Smstateen.pdf

--- a/rtl/cv32e40s_clic_int_controller.sv
+++ b/rtl/cv32e40s_clic_int_controller.sv
@@ -28,7 +28,7 @@
 
 module cv32e40s_clic_int_controller import cv32e40s_pkg::*;
 #(
-  parameter int SMCLIC_ID_WIDTH = 5
+  parameter int CLIC_ID_WIDTH = 5
 )
 (
   input  logic                       clk,
@@ -36,7 +36,7 @@ module cv32e40s_clic_int_controller import cv32e40s_pkg::*;
 
   // CLIC interface
   input  logic                       clic_irq_i,                // CLIC interrupt pending
-  input  logic [SMCLIC_ID_WIDTH-1:0] clic_irq_id_i,             // ID of pending interrupt
+  input  logic [CLIC_ID_WIDTH-1:0]   clic_irq_id_i,               // ID of pending interrupt
   input  logic [7:0]                 clic_irq_level_i,          // Level of pending interrupt
   input  logic [1:0]                 clic_irq_priv_i,           // Privilege level of pending interrupt (always machine mode) (not used)
   input  logic                       clic_irq_shv_i,            // Is pending interrupt vectored?
@@ -58,7 +58,7 @@ module cv32e40s_clic_int_controller import cv32e40s_pkg::*;
 
   // To cs_registers
   output logic                       mnxti_irq_pending_o,       // An interrupt is available to the mnxti CSR read
-  output logic [SMCLIC_ID_WIDTH-1:0] mnxti_irq_id_o,            // The id of the availble mnxti interrupt
+  output logic [CLIC_ID_WIDTH-1:0]   mnxti_irq_id_o,            // The id of the availble mnxti interrupt
   output logic [7:0]                 mnxti_irq_level_o          // Level of the available interrupt
 );
 
@@ -67,7 +67,7 @@ module cv32e40s_clic_int_controller import cv32e40s_pkg::*;
 
   // Flops for breaking timing path to instruction interface
   logic                       clic_irq_q;
-  logic [SMCLIC_ID_WIDTH-1:0] clic_irq_id_q;
+  logic [CLIC_ID_WIDTH-1:0]   clic_irq_id_q;
   logic [7:0]                 clic_irq_level_q;
   logic                       clic_irq_shv_q;
 
@@ -159,7 +159,7 @@ module cv32e40s_clic_int_controller import cv32e40s_pkg::*;
 
   // If mnxti_irq_pending is true, the currently flopped ID and level will be sent to cs_registers
   // for use in the function pointer and CSR side effects.
-  // Using native SMCLIC_ID_WIDTH for cleaner pointer concatenation in cs_registers.
+  // Using native CLIC_ID_WIDTH for cleaner pointer concatenation in cs_registers.
 
   assign mnxti_irq_id_o    = clic_irq_id_q;
   assign mnxti_irq_level_o = clic_irq_level_q;

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -33,8 +33,8 @@ module cv32e40s_controller import cv32e40s_pkg::*;
 #(
   parameter bit          X_EXT                  = 0,
   parameter int unsigned REGFILE_NUM_READ_PORTS = 2,
-  parameter bit          SMCLIC                 = 0,
-  parameter int          SMCLIC_ID_WIDTH        = 5,
+  parameter bit          CLIC                   = 0,
+  parameter int          CLIC_ID_WIDTH          = 5,
   parameter int          DEBUG                  = 1
 )
 (
@@ -150,8 +150,8 @@ module cv32e40s_controller import cv32e40s_pkg::*;
   cv32e40s_controller_fsm
   #(
     .X_EXT                       ( X_EXT                    ),
-    .SMCLIC                      ( SMCLIC                   ),
-    .SMCLIC_ID_WIDTH             ( SMCLIC_ID_WIDTH          ),
+    .CLIC                        ( CLIC                     ),
+    .CLIC_ID_WIDTH               ( CLIC_ID_WIDTH            ),
     .DEBUG                       ( DEBUG                    )
   )
   controller_fsm_i

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -31,10 +31,10 @@
 
 module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 #(
-  parameter bit       X_EXT           = 0,
-  parameter int       DEBUG           = 1,
-  parameter bit       SMCLIC          = 0,
-  parameter int       SMCLIC_ID_WIDTH = 5
+  parameter bit       X_EXT         = 0,
+  parameter int       DEBUG         = 1,
+  parameter bit       CLIC          = 0,
+  parameter int       CLIC_ID_WIDTH = 5
 )
 (
   // Clocks and reset
@@ -517,7 +517,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // Detect if there is a live CLIC pointer in the pipeline
   // This should block debug and interrupts
   generate
-    if (SMCLIC) begin : gen_clic_pointer_flag
+    if (CLIC) begin : gen_clic_pointer_flag
       // A CLIC pointer may be in the pipeline from the moment we start fetching (clic_ptr_in_progress_id == 1)
       // or while a pointer is in the EX or WB stages.
       assign clic_ptr_in_pipeline = (id_ex_pipe_i.instr_valid && id_ex_pipe_i.instr_meta.clic_ptr) ||
@@ -838,7 +838,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
           ctrl_fsm_o.csr_cause.minhv  = mcause_i.minhv;
 
 
-          if (SMCLIC) begin
+          if (CLIC) begin
             ctrl_fsm_o.csr_cause.exception_code = {1'b0, irq_id_ctrl_i};
             ctrl_fsm_o.irq_level = irq_clic_level_i;
             ctrl_fsm_o.irq_priv = irq_clic_priv_i;

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -40,9 +40,9 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   parameter logic [31:0] X_MISA           = 32'h00000000,
   parameter logic [1:0]  X_ECS_XS         = 2'b00, // todo: implement related mstatus bitfields (but only if X_EXT = 1)
   parameter bit          ZC_EXT           = 0,
-  parameter bit          SMCLIC           = 0,
-  parameter int          SMCLIC_ID_WIDTH  = 5,
-  parameter int          SMCLIC_INTTHRESHBITS = 8,
+  parameter bit          CLIC             = 0,
+  parameter int          CLIC_ID_WIDTH    = 5,
+  parameter int          CLIC_INTTHRESHBITS = 8,
   parameter int          NUM_MHPMCOUNTERS = 1,
   parameter int          PMP_NUM_REGIONS  = 0,
   parameter int          PMP_GRANULARITY  = 0,
@@ -115,7 +115,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   // Interrupts
   input  logic [31:0]                   mip_i,
   input  logic                          mnxti_irq_pending_i,
-  input  logic [SMCLIC_ID_WIDTH-1:0]    mnxti_irq_id_i,
+  input  logic [CLIC_ID_WIDTH-1:0]      mnxti_irq_id_i,
   input  logic [7:0]                    mnxti_irq_level_i,
   output logic                          clic_pa_valid_o,        // CSR read data is an address to a function pointer
   output logic [31:0]                   clic_pa_o,              // Address to CLIC function pointer
@@ -164,8 +164,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   localparam logic [31:0] MISA_VALUE = CORE_MISA | (X_EXT ? X_MISA : 32'h0000_0000);
 
-  // Set mask for minththresh based on number of bits implemented (SMCLIC_INTTHRESHBITS)
-  localparam CSR_MINTTHRESH_MASK = ((2 ** SMCLIC_INTTHRESHBITS )-1) << (8 - SMCLIC_INTTHRESHBITS);
+  // Set mask for minththresh based on number of bits implemented (CLIC_INTTHRESHBITS)
+  localparam CSR_MINTTHRESH_MASK = ((2 ** CLIC_INTTHRESHBITS )-1) << (8 - CLIC_INTTHRESHBITS);
 
   // CSR update logic
   logic [31:0]                  csr_wdata_int;
@@ -524,7 +524,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       // mtvt: machine trap-handler vector table base address
       CSR_MTVT: begin
-        if (SMCLIC) begin
+        if (CLIC) begin
           csr_rdata_int = mtvt_rdata;
         end else begin
           csr_rdata_int    = '0;
@@ -564,7 +564,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       // mnxti: Next Interrupt Handler Address and Interrupt Enable
       CSR_MNXTI: begin
-        if (SMCLIC) begin
+        if (CLIC) begin
           // The data read here is what will be used in the read-modify-write portion of the CSR access.
           // For mnxti, this is actually mstatus. The value written back to the GPR will be the address of
           // the function pointer to the interrupt handler. This is muxed in the WB stage.
@@ -578,7 +578,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       // mintstatus: Interrupt Status
       CSR_MINTSTATUS: begin
-        if (SMCLIC) begin
+        if (CLIC) begin
           csr_rdata_int = mintstatus_rdata;
         end else begin
           csr_rdata_int    = '0;
@@ -588,7 +588,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       // mintthresh: Interrupt-Level Threshold
       CSR_MINTTHRESH: begin
-        if (SMCLIC) begin
+        if (CLIC) begin
           csr_rdata_int = mintthresh_rdata;
         end else begin
           csr_rdata_int    = '0;
@@ -598,7 +598,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       // mscratchcsw: Scratch Swap for Multiple Privilege Modes
       CSR_MSCRATCHCSW: begin
-        if (SMCLIC) begin
+        if (CLIC) begin
           // CLIC spec 13.2
           // Depending on mstatus.MPP, we return either mscratch_rdata or rs1 to rd.
           // Safe to use mstatus_rdata here (EX timing), as there is a generic stall of the ID stage
@@ -619,7 +619,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       // mscratchcswl: Scratch Swap for Interrupt Levels
       CSR_MSCRATCHCSWL: begin
-        if (SMCLIC) begin
+        if (CLIC) begin
           // CLIC spec 14.1
           // Depending on mcause.pil and mintstatus.mil, either mscratch or rs1 is returned to rd.
           // Safe to use mcause_rdata and mintstatus_rdata here (EX timing), as there is a generic stall of the ID stage
@@ -697,6 +697,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           csr_rdata_int = dcsr_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
+          csr_rdata_int    = '0;
           illegal_csr_read = 1'b1;
         end
       end
@@ -706,6 +707,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           csr_rdata_int = dpc_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
+          csr_rdata_int    = '0;
           illegal_csr_read = 1'b1;
         end
       end
@@ -715,6 +717,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           csr_rdata_int = dscratch0_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
+          csr_rdata_int    = '0;
           illegal_csr_read = 1'b1;
         end
       end
@@ -724,6 +727,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           csr_rdata_int = dscratch1_rdata;
           illegal_csr_read = !ctrl_fsm_i.debug_mode;
         end else begin
+          csr_rdata_int    = '0;
           illegal_csr_read = 1'b1;
         end
       end
@@ -1051,7 +1055,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     mtvec_n.submode = mtvec_rdata.submode;
     mtvec_we        = csr_mtvec_init_i;
 
-    if (SMCLIC) begin
+    if (CLIC) begin
       mtvec_n.mode             = mtvec_mode_clic_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]); // mode is WARL 0x3 when using CLIC
 
       mtvt_n                   = {csr_wdata_int[31:(32-MTVT_ADDR_WIDTH)], {(32-MTVT_ADDR_WIDTH){1'b0}}};
@@ -1088,7 +1092,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
                                   };
       mcause_we                = 1'b0;
       mcause_alias_we          = 1'b0;
-    end else begin // !SMCLIC
+    end else begin // !CLIC
       mtvec_n.mode             = csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clint_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]);
 
       mtvt_n                   = '0;
@@ -1207,10 +1211,10 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         // mstatus
         CSR_MSTATUS: begin
           mstatus_we = 1'b1;
-          // CLIC mode is assumed when SMCLIC = 1
+          // CLIC mode is assumed when CLIC = 1
           // For CLIC, a write to mstatus.mpp or mstatus.mpie will write to the
           // corresponding bits in mstatus as well.
-          if (SMCLIC) begin
+          if (CLIC) begin
             mcause_alias_we = 1'b1;
           end
         end
@@ -1238,7 +1242,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
         // mtvt: machine trap-handler vector table base address
         CSR_MTVT: begin
-          if (SMCLIC) begin
+          if (CLIC) begin
             mtvt_we = 1'b1;
           end
         end
@@ -1260,10 +1264,10 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         // mcause
         CSR_MCAUSE: begin
           mcause_we = 1'b1;
-          // CLIC mode is assumed when SMCLIC = 1
+          // CLIC mode is assumed when CLIC = 1
           // For CLIC, a write to mcause.mpp or mcause.mpie will write to the
           // corresponding bits in mstatus as well.
-          if (SMCLIC) begin
+          if (CLIC) begin
             mstatus_alias_we = 1'b1;
           end
         end
@@ -1278,7 +1282,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         end
 
         CSR_MNXTI: begin
-          if (SMCLIC) begin
+          if (CLIC) begin
             mnxti_we = 1'b1;
 
             // Writes to mnxti also writes to mstatus (uses mstatus in the RMW operation)
@@ -1299,19 +1303,19 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         end
 
         CSR_MINTSTATUS: begin
-          if (SMCLIC) begin
+          if (CLIC) begin
             mintstatus_we = 1'b1;
           end
         end
 
         CSR_MINTTHRESH: begin
-          if (SMCLIC) begin
+          if (CLIC) begin
             mintthresh_we = 1'b1;
           end
         end
 
         CSR_MSCRATCHCSW: begin
-          if (SMCLIC) begin
+          if (CLIC) begin
             // mscratchcsw operates on mscratch
             // Writing only when mstatus.mpp != PRIV_LVL_M
             if (mstatus_rdata.mpp != PRIV_LVL_M) begin
@@ -1322,7 +1326,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         end
 
         CSR_MSCRATCHCSWL: begin
-          if (SMCLIC) begin
+          if (CLIC) begin
             // mscratchcswl operates on mscratch
             if ((mcause_rdata.mpil == '0) != (mintstatus_rdata.mil == '0)) begin
               mscratchcswl_we = 1'b1;
@@ -1522,8 +1526,8 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
     // CSR side effects from other CSRs
 
-    // CLIC mode is assumed when SMCLIC = 1
-    if (SMCLIC) begin
+    // CLIC mode is assumed when CLIC = 1
+    if (CLIC) begin
       if (mnxti_we) begin
         // Mstatus is written as part of an mnxti access
         // Make sure we alias the mpp/mpie to mcause
@@ -1617,7 +1621,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           mcause_we = 1'b1;
 
 
-          if (SMCLIC) begin
+          if (CLIC) begin
             // mpil is saved from mintstatus
             mcause_n.mpil = mintstatus_rdata.mil;
 
@@ -1657,7 +1661,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         mstatus_n.mprv = (privlvl_t'(mstatus_rdata.mpp) == PRIV_LVL_M) ? mstatus_rdata.mprv : 1'b0;
         mstatus_we     = 1'b1;
 
-        if (SMCLIC) begin
+        if (CLIC) begin
           mintstatus_n.mil = mcause_rdata.mpil;
           mintstatus_we = 1'b1;
 
@@ -1684,7 +1688,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         mstatus_n.mprv = (privlvl_t'(dcsr_rdata.prv) == PRIV_LVL_M) ? mstatus_rdata.mprv : 1'b0;
         mstatus_we     = 1'b1;
 
-        if (SMCLIC) begin
+        if (CLIC) begin
           // Not really needed, but allows for asserting mstatus_we == mcause_we to check aliasing formally
           mcause_n       = mcause_rdata;
           mcause_we      = 1'b1;
@@ -1697,7 +1701,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       // In the case of mret restarting CLIC pointer fetches, minhv is cleared while
       // ctrl_fsm_i.csr_restore_mret_ptr is asserted.
       ctrl_fsm_i.csr_clear_minhv: begin
-        if (SMCLIC) begin
+        if (CLIC) begin
           // Keep mcause values, only clear minhv bit.
           mcause_n = mcause_rdata;
           mcause_n.minhv = 1'b0;
@@ -1927,9 +1931,9 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
 
   generate
-    if (SMCLIC) begin : smclic_csrs
+    if (CLIC) begin : clic_csrs
 
-      assign mie_q = 32'h0;                                                     // CLIC mode is assumed when SMCLIC = 1
+      assign mie_q = 32'h0;                                                     // CLIC mode is assumed when CLIC = 1
       assign mie_rd_error = 1'b0;
 
       cv32e40s_csr
@@ -2551,9 +2555,9 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   // Implemented threshold bits are left justified, unimplemented bits are tied to 1.
   // Special case when all 8 bits are implemented to avoid zero-replication
   generate
-    if (SMCLIC_INTTHRESHBITS < 8) begin : gen_partial_thresh
+    if (CLIC_INTTHRESHBITS < 8) begin : gen_partial_thresh
       // Unimplemented bits within [7:0] are tied to 1. Bits 31:8 always tied to 0.
-      assign mintthresh_rdata   = {mintthresh_q[31:(7-(SMCLIC_INTTHRESHBITS-1))], {(8-SMCLIC_INTTHRESHBITS) {1'b1}}};
+      assign mintthresh_rdata   = {mintthresh_q[31:(7-(CLIC_INTTHRESHBITS-1))], {(8-CLIC_INTTHRESHBITS) {1'b1}}};
     end else begin : gen_full_thresh
       // Bits 31:8 tied to 0, all bits within [7:0] are implemented in flipflops.
       assign mintthresh_rdata   = mintthresh_q[31:0];
@@ -2615,7 +2619,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
   // Signal when an interrupt may become enabled due to a CSR write
   generate
-    if (SMCLIC) begin : smclic_irq_en
+    if (CLIC) begin : clic_irq_en
       assign csr_irq_enable_write_o = mstatus_we || priv_lvl_we || mintthresh_we || mintstatus_we;
     end else begin : basic_irq_en
       assign csr_irq_enable_write_o = mie_we || mstatus_we || priv_lvl_we;

--- a/rtl/cv32e40s_decoder.sv
+++ b/rtl/cv32e40s_decoder.sv
@@ -32,7 +32,7 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
   parameter b_ext_e      B_EXT                  = B_NONE,
   parameter m_ext_e      M_EXT                  = M,
   parameter              DEBUG_TRIGGER_EN       = 1,
-  parameter bit          SMCLIC                 = 1
+  parameter bit          CLIC                   = 1
 )
 (
   // singals running to/from controller
@@ -140,7 +140,7 @@ module cv32e40s_decoder import cv32e40s_pkg::*;
   cv32e40s_i_decoder
   #(
     .DEBUG_TRIGGER_EN (DEBUG_TRIGGER_EN),
-    .SMCLIC           (SMCLIC          )
+    .CLIC             (CLIC            )
   )
   i_decoder_i
   (

--- a/rtl/cv32e40s_i_decoder.sv
+++ b/rtl/cv32e40s_i_decoder.sv
@@ -30,7 +30,7 @@
 module cv32e40s_i_decoder import cv32e40s_pkg::*;
   #(
     parameter     DEBUG_TRIGGER_EN  = 1,
-    parameter bit SMCLIC            = 1
+    parameter bit CLIC              = 1
     )
   (
    // from IF/ID pipeline
@@ -400,7 +400,7 @@ module cv32e40s_i_decoder import cv32e40s_pkg::*;
             end
           end
 
-          if (SMCLIC) begin
+          if (CLIC) begin
             // The mscratchcsw[l] CSRs are only accessible using CSRRW with neither rd nor rs1 set to x0
             if ((instr_rdata_i[31:20] == CSR_MSCRATCHCSW) || (instr_rdata_i[31:20] == CSR_MSCRATCHCSWL)) begin
               if (instr_rdata_i[14:12] == 3'b001) begin // CSRRW
@@ -435,7 +435,7 @@ module cv32e40s_i_decoder import cv32e40s_pkg::*;
                 end
               end
             end
-          end // SMCLIC
+          end // CLIC
         end
       end
 

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -38,7 +38,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
   parameter bit          X_EXT                  = 0,
   parameter              DEBUG_TRIGGER_EN       = 1,
   parameter int unsigned REGFILE_NUM_READ_PORTS = 2,
-  parameter bit          SMCLIC                 = 1
+  parameter bit          CLIC                   = 1
 )
 (
   input  logic        clk,                    // Gated clock
@@ -450,7 +450,7 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
     .B_EXT                           ( B_EXT                     ),
     .M_EXT                           ( M_EXT                     ),
     .DEBUG_TRIGGER_EN                ( DEBUG_TRIGGER_EN          ),
-    .SMCLIC                          ( SMCLIC                    )
+    .CLIC                            ( CLIC                      )
   )
   decoder_i
   (

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -38,8 +38,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   parameter int          PMP_NUM_REGIONS = 0,
   parameter bit          DUMMY_INSTRUCTIONS = 0,
   parameter int unsigned MTVT_ADDR_WIDTH = 26,
-  parameter bit          SMCLIC          = 1'b0,
-  parameter int          SMCLIC_ID_WIDTH = 5,
+  parameter bit          CLIC            = 1'b0,
+  parameter int          CLIC_ID_WIDTH   = 5,
   parameter bit          ZC_EXT          = 0,
   parameter m_ext_e      M_EXT           = M_NONE,
   parameter int          DEBUG           = 1,
@@ -212,7 +212,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
       PC_TRAP_DBD:   branch_addr_n = {dm_halt_addr_i[31:2], 2'b0};
       PC_TRAP_DBE:   branch_addr_n = {dm_exception_addr_i[31:2], 2'b0};
       PC_TRAP_NMI:   branch_addr_n = {mtvec_addr_i, ctrl_fsm_i.nmi_mtvec_index, 2'b00};
-      PC_TRAP_CLICV: branch_addr_n = {mtvt_addr_i, ctrl_fsm_i.mtvt_pc_mux[SMCLIC_ID_WIDTH-1:0], 2'b00};
+      PC_TRAP_CLICV: branch_addr_n = {mtvt_addr_i, ctrl_fsm_i.mtvt_pc_mux[CLIC_ID_WIDTH-1:0], 2'b00};
       // CLIC and Zc* spec requires to clear bit 0. This clearing is done in the alignment buffer.
       PC_POINTER :   branch_addr_n = if_id_pipe_o.ptr;
       // JVT + (index << 2)
@@ -228,7 +228,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   // prefetch buffer, caches a fixed number of instructions
   cv32e40s_prefetch_unit
   #(
-      .SMCLIC          (SMCLIC),
+      .CLIC            (CLIC),
       .ALBUF_DEPTH     (ALBUF_DEPTH),
       .ALBUF_CNT_WIDTH (ALBUF_CNT_WIDTH)
   )

--- a/rtl/cv32e40s_prefetch_unit.sv
+++ b/rtl/cv32e40s_prefetch_unit.sv
@@ -28,7 +28,7 @@
 
 module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
 #(
-    parameter bit SMCLIC                   = 1'b0,
+    parameter bit CLIC                     = 1'b0,
     parameter int unsigned ALBUF_DEPTH     = 3,
     parameter int unsigned ALBUF_CNT_WIDTH = $clog2(ALBUF_DEPTH)
 )
@@ -88,7 +88,7 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
 
   cv32e40s_prefetcher
   #(
-      .SMCLIC  (SMCLIC)
+      .CLIC  (CLIC)
   )
   prefetcher_i
   (

--- a/rtl/cv32e40s_prefetcher.sv
+++ b/rtl/cv32e40s_prefetcher.sv
@@ -39,7 +39,7 @@
 
 module cv32e40s_prefetcher import cv32e40s_pkg::*;
 #(
-    parameter bit SMCLIC = 1'b0
+    parameter bit CLIC = 1'b0
 )
 (
   input  logic                     clk,

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -456,7 +456,7 @@ typedef enum logic[11:0] {
   CSR_MIMPID         = 12'hF13,
   CSR_MHARTID        = 12'hF14,
   CSR_MCONFIGPTR     = 12'hF15,
-  CSR_MINTSTATUS     = 12'hF46,
+  CSR_MINTSTATUS     = 12'hFB1,
 
   // Xsecure custom CSRs
   CSR_CPUCTRL        = 12'hBF0,

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -30,7 +30,7 @@ module cv32e40s_controller_fsm_sva
   import cv32e40s_pkg::*;
   #(  parameter bit X_EXT     = 1'b0,
       parameter int DEBUG     = 0,
-      parameter bit SMCLIC    = 1'b0
+      parameter bit CLIC      = 1'b0
   )
 (
   input logic           clk,
@@ -699,7 +699,7 @@ endgenerate
                     (valid_cnt < (retire_at_error ? 2'b10 : 2'b11)))
     else `uvm_error("controller", "NMI handler not taken within two instruction retirements")
 
-if (SMCLIC) begin
+if (CLIC) begin
 
   // After a pc_set to PC_TRAP_CLICV, only the following jump targets are allowed:
   // PC_POINTER : Normal execution, the pointer target is being fetched
@@ -729,7 +729,7 @@ if (SMCLIC) begin
                   !ctrl_fsm_o.kill_id)
     else `uvm_error("controller", "ID stage killed while clic_ptr_in_progress_id is high")
 
-end else begin // SMCLIC
+end else begin // CLIC
   // Check that CLIC related signals are inactive when CLIC is not configured.
   a_clic_inactive:
   assert property (@(posedge clk) disable iff (!rst_n)

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -27,7 +27,7 @@ module cv32e40s_core_sva
   import cv32e40s_pkg::*;
   #(
     parameter int PMA_NUM_REGIONS = 0,
-    parameter bit SMCLIC = 0,
+    parameter bit CLIC = 0,
     parameter int REGFILE_NUM_READ_PORTS = 2,
     parameter int DEBUG = 1
   )
@@ -148,7 +148,7 @@ module cv32e40s_core_sva
   input logic        last_sec_op_id_i,  // todo: liekely not needed when using last_op_id.
   input logic        last_op_id);
 
-if (SMCLIC) begin
+if (CLIC) begin
   property p_clic_mie_tieoff;
     @(posedge clk)
     |mie == 1'b0;
@@ -163,7 +163,7 @@ if (SMCLIC) begin
 
   //todo: add CLIC related assertions (level thresholds etc)
 end else begin
-  // SMCLIC == 0
+  // CLIC == 0
   // Check that a taken IRQ is actually enabled (e.g. that we do not react to an IRQ that was just disabled in MIE)
   // The actual mie_n value may be different from mie_q if mie is not
   // written to.
@@ -188,7 +188,7 @@ end else begin
 
   a_irq_enabled_1 : assert property(p_irq_enabled_1) else `uvm_error("core", "Assertion a_irq_enabled_1 failed")
 
-  // Assert that no pointer can be in any pipeline stage when SMCLIC == 0
+  // Assert that no pointer can be in any pipeline stage when CLIC == 0
   property p_clic_noptr_in_pipeline;
     @(posedge clk) disable iff (!rst_ni)
       1'b1
@@ -198,7 +198,7 @@ end else begin
   endproperty
 
   a_clic_noptr_in_pipeline : assert property(p_clic_noptr_in_pipeline) else `uvm_error("core", "CLIC pointer in pipeline when CLIC is not configured.")
-end // SMCLIC
+end // CLIC
 
 // First illegal instruction decoded
 logic         first_illegal_found;
@@ -421,7 +421,7 @@ always_ff @(posedge clk , negedge rst_ni)
     end
 
 
-if (SMCLIC) begin
+if (CLIC) begin
   if (DEBUG) begin
     // Non-SHV interrupt taken during single stepping.
     // If this happens, no instructions should retire until the core is in debug mode.
@@ -710,7 +710,7 @@ a_jumpr_self_stall_qual:
   a_tbljmp_stall: assert property(p_tbljmp_stall)
     else `uvm_error("core", "Table jump not stalled while CSR is written");
 
-if (!SMCLIC) begin
+if (!CLIC) begin
   // Check that a pending interrupt is taken as soon as possible after being enabled
   property p_mip_mie_write_enable;
     @(posedge clk) disable iff (!rst_ni)

--- a/sva/cv32e40s_cs_registers_sva.sv
+++ b/sva/cv32e40s_cs_registers_sva.sv
@@ -26,7 +26,7 @@ module cv32e40s_cs_registers_sva
   import uvm_pkg::*;
   import cv32e40s_pkg::*;
 #(
-    parameter bit SMCLIC = 0,
+    parameter bit CLIC = 0,
     parameter int PMP_ADDR_WIDTH = 32,
     parameter int DEBUG  = 1
   )
@@ -92,7 +92,7 @@ module cv32e40s_cs_registers_sva
                   |-> !csr_we_int)
     else `uvm_error("wb_stage", "Register file written while WB is halted or killed")
 
-  if (SMCLIC) begin
+  if (CLIC) begin
     // Assert that mtvec[1:0] are always 2'b11
     a_mtvec_mode_clic:
     assert property (@(posedge clk) disable iff (!rst_n)

--- a/sva/cv32e40s_prefetch_unit_sva.sv
+++ b/sva/cv32e40s_prefetch_unit_sva.sv
@@ -21,7 +21,7 @@
 module cv32e40s_prefetch_unit_sva import cv32e40s_pkg::*;
   import uvm_pkg::*;
   #(
-        parameter SMCLIC = 1'b0
+        parameter CLIC = 1'b0
   )
   (
    input logic        clk,
@@ -58,7 +58,7 @@ module cv32e40s_prefetch_unit_sva import cv32e40s_pkg::*;
   a_branch_implies_req : assert property(p_branch_implies_req)
     else `uvm_error("prefetch_buffer", "Assertion a_branch_implies_req failed")
 
-if (SMCLIC) begin
+if (CLIC) begin
   // Shall not fetch anything between pointer fetch and the actual instruction fetch
   // based on the pointer.
   property p_single_ptr_fetch;
@@ -70,7 +70,7 @@ if (SMCLIC) begin
     assert property(p_single_ptr_fetch)
     else
       `uvm_error("Alignment buffer SVA", "Multiple fetches for CLIC/Zc pointer")
-end // SMCLIC
+end // CLIC
 
 
 endmodule // cv32e40s_prefetch_unit

--- a/sva/cv32e40s_prefetcher_sva.sv
+++ b/sva/cv32e40s_prefetcher_sva.sv
@@ -29,7 +29,7 @@
 
 module cv32e40s_prefetcher_sva import cv32e40s_pkg::*;
 #(
-    parameter bit SMCLIC = 1'b0
+    parameter bit CLIC = 1'b0
 )
 (
   input  logic        clk,
@@ -172,7 +172,7 @@ module cv32e40s_prefetcher_sva import cv32e40s_pkg::*;
       `uvm_error("Prefetcher SVA",
                 $sformatf("First fetch after reset is not a branch"))
 
-if (SMCLIC) begin
+if (CLIC) begin
   // We cannot have a new fetch_branch when a CLIC pointer fetch is outstanding. If that happens, the core will lose track of
   // which which address to return to (mepc, dpc) as the pointer is not associated with an actual instruction.
   // For Zc pointer fetches, we can allow this (for instance debug entry or exception while the pointer is outstanding).
@@ -186,5 +186,5 @@ if (SMCLIC) begin
     assert property(p_data_q_no_branch)
     else
       `uvm_error("Prefetcher SVA", "data_q is set on branch.")
-end // SMCLIC
+end // CLIC
 endmodule: cv32e40s_prefetcher_sva

--- a/sva/cv32e40s_rvfi_sva.sv
+++ b/sva/cv32e40s_rvfi_sva.sv
@@ -28,7 +28,7 @@ module cv32e40s_rvfi_sva
   import cv32e40s_pkg::*;
   import cv32e40s_rvfi_pkg::*;
 #(
-    parameter bit SMCLIC = 0,
+    parameter bit CLIC   = 0,
     parameter int DEBUG  = 1
 )
 (

--- a/yaml/csr.yaml.m4
+++ b/yaml/csr.yaml.m4
@@ -3141,7 +3141,7 @@ ifelse(eval(CLIC != 0), 1, [[[
   rv32:
     - field_name: BASE_31_N
       description: >
-        Trap-handler vector base address. Alignment depends on SMCLIC_ID_WIDTH parameter.
+        Trap-handler vector base address. Alignment depends on CLIC_ID_WIDTH parameter.
       type: WARL
       reset_val: 0
       msb: 31
@@ -4388,7 +4388,7 @@ ifelse(eval(CLIC != 0), 1, [[[
 - csr: mintstatus
   description: >
     Machine interrupt status
-  address: 0xF46
+  address: 0xFB1
   privilege_mode: M
   rv32:
     - field_name: MIL


### PR DESCRIPTION
Includes relocating the mintstatus CSR to address 0xFB1, renaming SMCLIC to CLIC and removal of latches in cs_registers when DEBUG=0.

SEC clean with the exception of the new address for mintstatus.
