### PR TITLE
Partial fix for X-issue #766

### DIFF
--- a/rtl/cv32e40s_csr.sv
+++ b/rtl/cv32e40s_csr.sv
@@ -71,15 +71,21 @@ module cv32e40s_csr #(
       end
 
     end else begin : gen_unhardened
-
-      always_ff @(posedge clk or negedge rst_n) begin
-        if (!rst_n) begin
-          rdata_q <= RESETVALUE & MASK;
-        end else if (wr_en_i) begin
-          rdata_q <= wr_data_i & MASK;
+      for (genvar i = 0; i < WIDTH; i++) begin : gen_csr
+        if (MASK[i]) begin : gen_unmasked
+          // Bits with mask set are actual flipflops
+          always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) begin
+              rdata_q[i] <= RESETVALUE[i];
+            end else if (wr_en_i) begin
+              rdata_q[i] <= wr_data_i[i];
+            end
+          end
+        end else begin : gen_masked
+          // Bits with mask cleared are tied off to the reset value
+          assign rdata_q[i] = RESETVALUE[i];
         end
-      end
-
+      end // for
       assign rd_error_o = 1'b0;
     end
   endgenerate


### PR DESCRIPTION
Refactored CSR code when SHADOWCOPY==0. If a CSR bit was 1 in the reset value while the corresponding mask bit was 0 the resulting bit in the CSR would be 0.

SEC clean when turning off shadowcopy in the impl and not the spec.