### PR TITLE
Fixed rvfi write mask issue

### DIFF
--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -1429,7 +1429,7 @@ module cv32e40s_rvfi
   assign rvfi_csr_rdata_d.tselect            = csr_tselect_q_i;
   assign rvfi_csr_rmask_d.tselect            = '1;
   assign rvfi_csr_wdata_d.tselect            = csr_tselect_n_i;
-  assign rvfi_csr_wmask_d.tselect            = csr_tselect_we_i;
+  assign rvfi_csr_wmask_d.tselect            = csr_tselect_we_i ? '1 : '0;
 
   // Tdata0 does not exist, tie off to zero
   assign rvfi_csr_rdata_d.tdata[0]           = '0;
@@ -1450,12 +1450,12 @@ module cv32e40s_rvfi
   assign rvfi_csr_rdata_d.tdata[3]           = csr_tdata3_q_i;
   assign rvfi_csr_rmask_d.tdata[3]           = '1;
   assign rvfi_csr_wdata_d.tdata[3]           = csr_tdata3_n_i;
-  assign rvfi_csr_wmask_d.tdata[3]           = csr_tdata3_we_i;
+  assign rvfi_csr_wmask_d.tdata[3]           = csr_tdata3_we_i ? '1 : '0;
 
   assign rvfi_csr_rdata_d.tinfo              = csr_tinfo_q_i;
   assign rvfi_csr_rmask_d.tinfo              = '1;
   assign rvfi_csr_wdata_d.tinfo              = csr_tinfo_n_i;
-  assign rvfi_csr_wmask_d.tinfo              = csr_tinfo_we_i;
+  assign rvfi_csr_wmask_d.tinfo              = csr_tinfo_we_i ? '1 : '0;
 
   assign rvfi_csr_rdata_d.tcontrol           = csr_tcontrol_q_i;
   assign rvfi_csr_rmask_d.tcontrol           = '1;


### PR DESCRIPTION
Fixed issue with rvfi write masks for tselect, tinfo and tdata3 (https://github.com/openhwgroup/cv32e40s/issues/417).