### PR TITLE
Merge from CV32E40X

### DIFF
--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -167,8 +167,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   // Set mask for minththresh based on number of bits implemented (CLIC_INTTHRESHBITS)
   localparam CSR_MINTTHRESH_MASK = ((2 ** CLIC_INTTHRESHBITS )-1) << (8 - CLIC_INTTHRESHBITS);
 
-  localparam logic [31:0] CSR_MTVT_MASK = {{MTVT_ADDR_WIDTH{1'b1}}, {32-MTVT_ADDR_WIDTH{1'b0}}};
-
+  localparam logic [31:0] CSR_MTVT_MASK = {{MTVT_ADDR_WIDTH{1'b1}}, {(32-MTVT_ADDR_WIDTH){1'b0}}};
 
   // CSR update logic
   logic [31:0]                  csr_wdata_int;
@@ -1017,10 +1016,10 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
                                     CSR_DCSR_MASK, DCSR_RESET_VAL);
     dcsr_we       = 1'b0;
 
-    dscratch0_n   = csr_wdata_int;
+    dscratch0_n   = csr_next_value(csr_wdata_int, CSR_DSCRATCH0_MASK, DSCRATCH0_RESET_VAL);
     dscratch0_we  = 1'b0;
 
-    dscratch1_n   = csr_wdata_int;
+    dscratch1_n   = csr_next_value(csr_wdata_int, CSR_DSCRATCH1_MASK, DSCRATCH1_RESET_VAL);
     dscratch1_we  = 1'b0;
 
     tselect_we    = 1'b0;
@@ -1036,14 +1035,15 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     tcontrol_we   = 1'b0;
 
     // TODO: add support for SD/XS/FS/VS
-    mstatus_n     = '{
-                                  tw:   csr_wdata_int[MSTATUS_TW_BIT],
-                                  mprv: mstatus_mprv_resolve(mstatus_rdata.mprv, csr_wdata_int[MSTATUS_MPRV_BIT]),
-                                  mpp:  mstatus_mpp_resolve(mstatus_rdata.mpp, csr_wdata_int[MSTATUS_MPP_BIT_HIGH:MSTATUS_MPP_BIT_LOW]),
-                                  mpie: csr_wdata_int[MSTATUS_MPIE_BIT],
-                                  mie:  csr_wdata_int[MSTATUS_MIE_BIT],
-                                  default: 'b0
-                                };
+    mstatus_n     = csr_next_value(mstatus_t'{
+                                              tw:   csr_wdata_int[MSTATUS_TW_BIT],
+                                              mprv: mstatus_mprv_resolve(mstatus_rdata.mprv, csr_wdata_int[MSTATUS_MPRV_BIT]),
+                                              mpp:  mstatus_mpp_resolve(mstatus_rdata.mpp, csr_wdata_int[MSTATUS_MPP_BIT_HIGH:MSTATUS_MPP_BIT_LOW]),
+                                              mpie: csr_wdata_int[MSTATUS_MPIE_BIT],
+                                              mie:  csr_wdata_int[MSTATUS_MIE_BIT],
+                                              default: 'b0
+                                            },
+                                  CSR_MSTATUS_MASK, MSTATUS_RESET_VAL);
     mstatus_we    = 1'b0;
 
     mstatush_n    = mstatush_rdata; // Read only
@@ -1056,15 +1056,17 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     priv_lvl_n    = priv_lvl_rdata;
     priv_lvl_we   = 1'b0;
 
-    mtvec_n.addr    = csr_mtvec_init_i ? mtvec_addr_i[31:7] : csr_wdata_int[31:7];
-    mtvec_n.zero0   = mtvec_rdata.zero0;
-    mtvec_n.submode = mtvec_rdata.submode;
-    mtvec_we        = csr_mtvec_init_i;
-
     if (CLIC) begin
-      mtvec_n.mode             = mtvec_mode_clic_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]); // mode is WARL 0x3 when using CLIC
+      mtvec_n       = csr_next_value(mtvec_t'{
+                                              addr:    csr_mtvec_init_i ? mtvec_addr_i[31:7] : csr_wdata_int[31:7],
+                                              zero0:   mtvec_rdata.zero0,
+                                              submode: mtvec_rdata.submode,
+                                              mode:    csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clic_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW])
+                                            },
+                                      CSR_CLIC_MTVEC_MASK, MTVEC_CLIC_RESET_VAL);
+      mtvec_we        = csr_mtvec_init_i;
 
-      mtvt_n                   = {csr_wdata_int[31:(32-MTVT_ADDR_WIDTH)], {(32-MTVT_ADDR_WIDTH){1'b0}}};
+      mtvt_n                   = csr_next_value({csr_wdata_int[31:(32-MTVT_ADDR_WIDTH)], {(32-MTVT_ADDR_WIDTH){1'b0}}}, CSR_MTVT_MASK, MTVT_RESET_VAL);
       mtvt_we                  = 1'b0;
 
       mnxti_we                 = 1'b0;
@@ -1072,13 +1074,13 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       mintstatus_n             = mintstatus_rdata; // Read only
       mintstatus_we            = 1'b0;
 
-      mintthresh_n             = csr_wdata_int & CSR_MINTTHRESH_MASK;
+      mintthresh_n             = csr_next_value(csr_wdata_int, CSR_MINTTHRESH_MASK, MINTTHRESH_RESET_VAL);
       mintthresh_we            = 1'b0;
 
       mscratchcsw_n            = mscratch_n; // mscratchcsw operates conditionally on mscratch
       mscratchcsw_we           = 1'b0;
 
-      mscratchcswl_n           = mscratch_n; // mscratchcswl operates conditionally on mscratch
+      mscratchcswl_n           = mscratch_n; // mscratchcsw operates conditionally on mscratch
       mscratchcswl_we          = 1'b0;
 
       mie_n                    = '0;
@@ -1087,19 +1089,27 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       mip_n                    = mip_rdata; // Read only;
       mip_we                   = 1'b0;
 
-      mcause_n                 = '{
-                                    irq:            csr_wdata_int[31],
-                                    minhv:          csr_wdata_int[30],
-                                    mpp:            mcause_mpp_resolve(mcause_rdata.mpp, csr_wdata_int[MCAUSE_MPP_BIT_HIGH:MCAUSE_MPP_BIT_LOW]),
-                                    mpie:           csr_wdata_int[MCAUSE_MPIE_BIT],
-                                    mpil:           csr_wdata_int[23:16],
-                                    exception_code: csr_wdata_int[10:0],
-                                    default:        'b0
-                                  };
+      mcause_n                 = csr_next_value(mcause_t'{
+                                                          irq:            csr_wdata_int[31],
+                                                          minhv:          csr_wdata_int[30],
+                                                          mpp:            mcause_mpp_resolve(mcause_rdata.mpp, csr_wdata_int[MCAUSE_MPP_BIT_HIGH:MCAUSE_MPP_BIT_LOW]),
+                                                          mpie:           csr_wdata_int[MCAUSE_MPIE_BIT],
+                                                          mpil:           csr_wdata_int[23:16],
+                                                          exception_code: csr_wdata_int[10:0],
+                                                          default:        'b0
+                                                        },
+                                                CSR_CLIC_MCAUSE_MASK, MCAUSE_CLIC_RESET_VAL);
       mcause_we                = 1'b0;
       mcause_alias_we          = 1'b0;
     end else begin // !CLIC
-      mtvec_n.mode             = csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clint_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW]);
+      mtvec_n                  = csr_next_value(mtvec_t'{
+                                                        addr:    csr_mtvec_init_i ? mtvec_addr_i[31:7] : csr_wdata_int[31:7],
+                                                        zero0:   mtvec_rdata.zero0,
+                                                        submode: mtvec_rdata.submode,
+                                                        mode:    csr_mtvec_init_i ? mtvec_rdata.mode : mtvec_mode_clint_resolve(mtvec_rdata.mode, csr_wdata_int[MTVEC_MODE_BIT_HIGH:MTVEC_MODE_BIT_LOW])
+                                                      },
+                                                CSR_BASIC_MTVEC_MASK, MTVEC_BASIC_RESET_VAL);
+      mtvec_we                 = csr_mtvec_init_i;
 
       mtvt_n                   = '0;
       mtvt_we                  = 1'b0;
@@ -1118,17 +1128,18 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       mscratchcswl_n           = '0;
       mscratchcswl_we          = 1'b0;
 
-      mie_n                    = csr_wdata_int & IRQ_MASK;
+      mie_n                    = csr_next_value(csr_wdata_int, IRQ_MASK, MIE_BASIC_RESET_VAL);
       mie_we                   = 1'b0;
 
       mip_n                    = mip_rdata; // Read only;
       mip_we                   = 1'b0;
 
-      mcause_n                 = '{
-                                    irq:            csr_wdata_int[31],
-                                    exception_code: csr_wdata_int[10:0],
-                                    default:        'b0
-                                  };
+      mcause_n                 = csr_next_value(mcause_t'{
+                                                          irq:            csr_wdata_int[31],
+                                                          exception_code: csr_wdata_int[10:0],
+                                                          default:        'b0
+                                                        },
+                                                        CSR_BASIC_MCAUSE_MASK, MCAUSE_BASIC_RESET_VAL);
       mcause_we                = 1'b0;
       mcause_alias_we          = 1'b0;
     end
@@ -1587,27 +1598,27 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         if (ctrl_fsm_i.debug_csr_save) begin
           // All interrupts are masked, don't update mcause, mepc, mtval, dpc and mstatus
           // dcsr.nmip is not a flop, but comes directly from the controller
-          dcsr_n         = '{
-            xdebugver : dcsr_rdata.xdebugver,
-            ebreakm   : dcsr_rdata.ebreakm,
-            ebreaku   : dcsr_rdata.ebreaku,
-            stepie    : dcsr_rdata.stepie,
-            stopcount : dcsr_rdata.stopcount,
-            mprven    : dcsr_rdata.mprven,
-            step      : dcsr_rdata.step,
-            prv       : priv_lvl_rdata,                 // Privilege level at time of debug entry
-            cause     : ctrl_fsm_i.debug_cause,
-            default   : 'd0
-          };
-          dcsr_we        = 1'b1;
+          dcsr_n         = dcsr_t'{
+                                    xdebugver : dcsr_rdata.xdebugver,
+                                    ebreakm   : dcsr_rdata.ebreakm,
+                                    ebreaku   : dcsr_rdata.ebreaku,
+                                    stepie    : dcsr_rdata.stepie,
+                                    stopcount : dcsr_rdata.stopcount,
+                                    mprven    : dcsr_rdata.mprven,
+                                    step      : dcsr_rdata.step,
+                                    prv       : priv_lvl_rdata,                 // Privilege level at time of debug entry
+                                    cause     : ctrl_fsm_i.debug_cause,
+                                    default   : 'd0
+                                  };
+dcsr_we        = 1'b1;
 
           dpc_n          = ctrl_fsm_i.pipe_pc;
           dpc_we         = 1'b1;
 
-          priv_lvl_n     = PRIV_LVL_M;                  // Execute with machine mode privilege in debug mode
+          priv_lvl_n     = PRIV_LVL_M;  // Execute with machine mode privilege in debug mode
           priv_lvl_we    = 1'b1;
         end else begin
-          priv_lvl_n     = PRIV_LVL_M;                  // Trap into machine mode
+          priv_lvl_n     = PRIV_LVL_M;  // Trap into machine mode
           priv_lvl_we    = 1'b1;
 
           mstatus_n      = mstatus_rdata;
@@ -1796,10 +1807,11 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     if (DEBUG) begin : gen_debug_csr
       cv32e40s_csr
       #(
-        .LIB        (LIB),
-        .WIDTH      (32),
-        .SHADOWCOPY (1'b0),
-        .RESETVALUE (32'd0)
+        .LIB        (LIB                ),
+        .WIDTH      (32                 ),
+        .SHADOWCOPY (1'b0               ),
+        .MASK       (CSR_DSCRATCH0_MASK ),
+        .RESETVALUE (DSCRATCH0_RESET_VAL)
       )
       dscratch0_csr_i
       (
@@ -1814,10 +1826,11 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       cv32e40s_csr
       #(
-        .LIB        (LIB),
-        .WIDTH      (32),
-        .SHADOWCOPY (1'b0),
-        .RESETVALUE (32'd0)
+        .LIB        (LIB                ),
+        .WIDTH      (32                 ),
+        .SHADOWCOPY (1'b0               ),
+        .MASK       (CSR_DSCRATCH1_MASK ),
+        .RESETVALUE (DSCRATCH1_RESET_VAL)
       )
       dscratch1_csr_i
       (
@@ -1853,6 +1866,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
       #(
         .LIB        (LIB),
         .WIDTH      (32),
+        .MASK       (CSR_DPC_MASK),
         .SHADOWCOPY (1'b0),
         .RESETVALUE (DPC_RESET_VAL)
       )
@@ -1944,9 +1958,10 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
 
       cv32e40s_csr
       #(
-        .LIB        (LIB),
-        .WIDTH      (32),
-        .SHADOWCOPY (1'b1),
+        .LIB        (LIB                  ),
+        .WIDTH      (32                   ),
+        .SHADOWCOPY (1'b1                 ),
+        .MASK       (CSR_CLIC_MCAUSE_MASK ),
         .RESETVALUE (MCAUSE_CLIC_RESET_VAL)
       )
       mcause_csr_i (
@@ -2022,7 +2037,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .WIDTH      (32),
         .MASK       (CSR_MINTTHRESH_MASK),
         .SHADOWCOPY (SECURE),
-        .RESETVALUE (32'h0)
+        .RESETVALUE (MINTTHRESH_RESET_VAL)
       )
       mintthresh_csr_i
       (
@@ -2043,6 +2058,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .LIB        (LIB),
         .WIDTH      (32),
         .SHADOWCOPY (1'b1),
+        .MASK       (CSR_BASIC_MCAUSE_MASK ),
         .RESETVALUE (MCAUSE_BASIC_RESET_VAL)
       )
       mcause_csr_i (
@@ -2080,7 +2096,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         .WIDTH      (32),
         .MASK       (IRQ_MASK),
         .SHADOWCOPY (SECURE),
-        .RESETVALUE (32'd0)
+        .RESETVALUE (MIE_BASIC_RESET_VAL)
       )
       mie_csr_i
       (

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -483,8 +483,16 @@ parameter CSR_CPUCTRL_MASK      = 32'h000F001F;
 parameter CSR_PMPNCFG_MASK      = 8'hFF;
 parameter CSR_PMPADDR_MASK      = 32'hFFFFFFFF;
 parameter CSR_MSECCFG_MASK      = 32'h00000007;
-parameter CSR_PRV_LVL_MASK      = 32'hFFFFFFFF;
+parameter CSR_PRV_LVL_MASK      = 32'hFFFFFFFF; // todo: should only be two bits
 parameter CSR_MSTATEEN0_MASK    = 32'h00000004;
+parameter CSR_DSCRATCH0_MASK    = 32'hFFFFFFFF;
+parameter CSR_DSCRATCH1_MASK    = 32'hFFFFFFFF;
+parameter CSR_MINTTHRESH_MASK   = 32'h000000FF;
+parameter CSR_CLIC_MCAUSE_MASK  = 32'b1111_1000_1111_1111_0000_0111_1111_1111;
+parameter CSR_BASIC_MCAUSE_MASK = 32'b1000_0000_0000_0000_0000_0111_1111_1111;
+parameter CSR_CLIC_MTVEC_MASK   = 32'hFFFFFF80;
+parameter CSR_BASIC_MTVEC_MASK  = 32'hFFFFFF81;
+
 
 // CSR operations
 
@@ -748,10 +756,14 @@ parameter mcause_t MCAUSE_CLIC_RESET_VAL = '{
 parameter mcause_t MCAUSE_BASIC_RESET_VAL = '{
     default: 'b0};
 
-parameter JVT_RESET_VAL      = 32'd0;
-parameter MSCRATCH_RESET_VAL = 32'd0;
-parameter MEPC_RESET_VAL     = 32'd0;
-parameter DPC_RESET_VAL      = 32'd0;
+parameter JVT_RESET_VAL                = 32'd0;
+parameter MSCRATCH_RESET_VAL           = 32'd0;
+parameter MEPC_RESET_VAL               = 32'd0;
+parameter DPC_RESET_VAL                = 32'd0;
+parameter DSCRATCH0_RESET_VAL          = 32'd0;
+parameter DSCRATCH1_RESET_VAL          = 32'd0;
+parameter MINTTHRESH_RESET_VAL         = 8'h00;
+parameter MIE_BASIC_RESET_VAL          = 32'd0;
 
 parameter logic [31:0] TDATA1_RST_VAL = {
   TTYPE_MCONTROL,        // type    : address/data match


### PR DESCRIPTION
SEC clean

The e40s-specific CSRs will get an update to use 'csr_next_value' after this PR.