### PR TITLE
Removed unused code related to privilege level of CLIC pointer fetche…

### DIFF
--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -259,7 +259,6 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic csr_irq_enable_write;
 
   privlvl_t     priv_lvl_lsu;
-  privlvl_t     priv_lvl_clic_ptr;
   privlvlctrl_t priv_lvl_if_ctrl;
 
   privlvl_t     priv_lvl;
@@ -621,7 +620,6 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     // Privilege level
     .priv_lvl_ctrl_i     ( priv_lvl_if_ctrl         ),
-    .priv_lvl_clic_ptr_i ( priv_lvl_clic_ptr        ),
 
     // Dummy Instruction control
     .xsecure_ctrl_i      ( xsecure_ctrl             ),
@@ -994,7 +992,6 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .priv_lvl_if_ctrl_o         ( priv_lvl_if_ctrl       ),
     .priv_lvl_lsu_o             ( priv_lvl_lsu           ),
     .priv_lvl_o                 ( priv_lvl               ),
-    .priv_lvl_clic_ptr_o        ( priv_lvl_clic_ptr      ),
 
     .sys_en_id_i                ( sys_en_id              ),
     .sys_mret_id_i              ( sys_mret_insn_id       ),

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -89,7 +89,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   output privlvl_t                      priv_lvl_o,
   output privlvlctrl_t                  priv_lvl_if_ctrl_o,
   output privlvl_t                      priv_lvl_lsu_o,
-  output privlvl_t                      priv_lvl_clic_ptr_o,
 
   // IF/ID pipeline
   input logic                           sys_en_id_i,
@@ -2308,19 +2307,6 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
     end
     else begin
       priv_lvl_lsu_o = mstatus_rdata.mprv ? privlvl_t'(mstatus_rdata.mpp) : id_ex_pipe_i.priv_lvl;
-    end
-  end
-
-  // Privilege level for CLIC pointer fetches in IF
-  // When an interrupt is taken, the pipeline is killed. The privilege level will be changed, so in case
-  // of a privilege level change, we need to use the level in the priv_lvl_if_ctrl_o when mprv is not set.
-  // priv_lvl_if_ctrl_o should carry the correct privilege level.
-  always_comb begin
-    if (mstatus_we) begin
-      priv_lvl_clic_ptr_o = mstatus_n.mprv ? privlvl_t'(mstatus_n.mpp) : priv_lvl_if_ctrl_o.priv_lvl;
-    end
-    else begin
-      priv_lvl_clic_ptr_o = mstatus_q.mprv ? privlvl_t'(mstatus_q.mpp) : priv_lvl_if_ctrl_o.priv_lvl;
     end
   end
 

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -107,7 +107,6 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   // Privilege mode
   input privlvlctrl_t   priv_lvl_ctrl_i,
-  input privlvl_t       priv_lvl_clic_ptr_i,    // Priv level for CLIC pointers. Must respect mstatus.mprv (done in cs_registers)
 
   // Dummy Instruction Control
   input xsecure_ctrl_t  xsecure_ctrl_i,


### PR DESCRIPTION
…s. Code was intended for use when CLIC pointer fetches were treated as data transactions.

SEC clean.