### PR TITLE
Removed todo in controller related to dummies and forward progress.

### DIFF
--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -299,7 +299,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   ////////////////////////////////////////////////////////////////////
   // - Blocking dummy instructions during single stepping and in debug mode.
   // - Blocking dummies if there is a non-first op in IF (sequencer is in the middle of a sequence)
-  // Todo: Use allow_dummy_instr to guarantee progress (ensure there are never two dummies in a row in any pipeline stage)
+  // a_no_back_to_back_dummy in if_stage_sva checks that dummies can't come back-to-back with no other instructions in between.
   assign  ctrl_fsm_o.allow_dummy_instr = !dcsr_i.step  &&  // Valid in IF because it can only be written in debug mode
                                          !debug_mode_q &&  // Valid in IF because pipeline is killed when entering and exiting debug
                                          (first_op_nondummy_if_i && prefetch_valid_if_i);


### PR DESCRIPTION
Updated assertion to chekc that we don't issue dummies back-to-backc without regular instructions in between.