### PR TITLE
Fix for issue #456

### DIFF
--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -913,7 +913,9 @@ module cv32e40s_rvfi
         if (is_dummy_instr_wb_i) begin
           dummy_suppressed_intr <= in_trap[STAGE_WB] || dummy_suppressed_intr;
         end else begin
-          dummy_suppressed_intr <= 1'b0;
+          if (last_op_wb_i) begin
+            dummy_suppressed_intr <= 1'b0;
+          end
         end
       end
     end

--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -913,6 +913,9 @@ module cv32e40s_rvfi
         if (is_dummy_instr_wb_i) begin
           dummy_suppressed_intr <= in_trap[STAGE_WB] || dummy_suppressed_intr;
         end else begin
+          // Only clear the flag once an instruction fully completes.
+          // Otherwise the first operation of a sequence could clear the flag, causing the
+          // rvfi_valid following (wb_valid && last_op) to miss it's rvfi_intr.
           if (last_op_wb_i) begin
             dummy_suppressed_intr <= 1'b0;
           end

--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -915,7 +915,7 @@ module cv32e40s_rvfi
         end else begin
           // Only clear the flag once an instruction fully completes.
           // Otherwise the first operation of a sequence could clear the flag, causing the
-          // rvfi_valid following (wb_valid && last_op) to miss it's rvfi_intr.
+          // rvfi_valid following (wb_valid && last_op) to miss its rvfi_intr.
           if (last_op_wb_i) begin
             dummy_suppressed_intr <= 1'b0;
           end

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -212,7 +212,7 @@ module cv32e40s_wrapper
     (
       .if_valid_i ( core_i.if_valid                   ),
       .id_ready_i ( core_i.id_ready                   ),
-      .hint_id_i  ( core_i.if_id_pipe.instr_meta.hint ),
+      .hint_if_i  ( core_i.if_stage_i.instr_hint      ),
       .*
     );
     end

--- a/rtl/cv32e40s_controller.sv
+++ b/rtl/cv32e40s_controller.sv
@@ -46,10 +46,8 @@ module cv32e40s_controller import cv32e40s_pkg::*;
 
   // From IF stage
   input  logic [31:0] pc_if_i,
-  input  logic        first_op_nondummy_if_i,
   input  logic        last_op_if_i,
   input  logic        abort_op_if_i,
-  input  logic        prefetch_valid_if_i,
 
   // from IF/ID pipeline
   input  if_id_pipe_t if_id_pipe_i,
@@ -163,10 +161,8 @@ module cv32e40s_controller import cv32e40s_pkg::*;
 
     .if_valid_i                  ( if_valid_i               ),
     .pc_if_i                     ( pc_if_i                  ),
-    .first_op_nondummy_if_i      ( first_op_nondummy_if_i   ),
     .last_op_if_i                ( last_op_if_i             ),
     .abort_op_if_i               ( abort_op_if_i            ),
-    .prefetch_valid_if_i         ( prefetch_valid_if_i      ),
 
     // From ID stage
     .if_id_pipe_i                ( if_id_pipe_i             ),

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -47,10 +47,8 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
   // From IF stage
   input  logic [31:0] pc_if_i,
-  input  logic        first_op_nondummy_if_i,     // IF stage is handling the first operation of a sequence
   input  logic        last_op_if_i,               // IF stage is handling the last operation of a sequence.
   input  logic        abort_op_if_i,              // IF stage contains an operation that will be aborted (bus error or MPU exception)
-  input  logic        prefetch_valid_if_i,        // Prefecher in IF stage has a valid instruction (similar as if_id_pipe.instr_valid)
 
   // From ID stage
   input  if_id_pipe_t if_id_pipe_i,

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -295,8 +295,8 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   // - Blocking dummies if there is a non-first op in IF (sequencer is in the middle of a sequence)
   // a_no_back_to_back_dummy in if_stage_sva checks that dummies can't come back-to-back with no other instructions in between.
   assign  ctrl_fsm_o.allow_dummy_instr = !dcsr_i.step  &&  // Valid in IF because it can only be written in debug mode
-                                         !debug_mode_q &&  // Valid in IF because pipeline is killed when entering and exiting debug
-                                         (first_op_nondummy_if_i && prefetch_valid_if_i);
+                                         !debug_mode_q;    // Valid in IF because pipeline is killed when entering and exiting debug
+
 
   // ID stage
 

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -292,7 +292,6 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
 
   ////////////////////////////////////////////////////////////////////
   // - Blocking dummy instructions during single stepping and in debug mode.
-  // - Blocking dummies if there is a non-first op in IF (sequencer is in the middle of a sequence)
   // a_no_back_to_back_dummy in if_stage_sva checks that dummies can't come back-to-back with no other instructions in between.
   assign  ctrl_fsm_o.allow_dummy_instr = !dcsr_i.step  &&  // Valid in IF because it can only be written in debug mode
                                          !debug_mode_q;    // Valid in IF because pipeline is killed when entering and exiting debug

--- a/rtl/cv32e40s_core.sv
+++ b/rtl/cv32e40s_core.sv
@@ -209,7 +209,6 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        abort_op_wb;
 
   // First op bits
-  logic        first_op_nondummy_if;
   logic        first_op_id;
   logic        first_op_ex;
 
@@ -301,7 +300,6 @@ module cv32e40s_core import cv32e40s_pkg::*;
   logic        ex_valid;
   logic        wb_valid;
 
-  logic        prefetch_valid_if;
 
   // Interrupts
   mstatus_t    mstatus;
@@ -572,11 +570,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
     .ptr_in_if_o         ( ptr_in_if                ),
     .priv_lvl_if_o       ( priv_lvl_if              ),
 
-    .first_op_nondummy_o ( first_op_nondummy_if     ),
     .last_op_o           ( last_op_if               ),
     .abort_op_o          ( abort_op_if              ),
-
-    .prefetch_valid_o    ( prefetch_valid_if        ),
 
     // Pipeline handshakes
     .if_valid_o          ( if_valid                 ),
@@ -1042,10 +1037,8 @@ module cv32e40s_core import cv32e40s_pkg::*;
 
     .if_valid_i                     ( if_valid               ),
     .pc_if_i                        ( pc_if                  ),
-    .first_op_nondummy_if_i         ( first_op_nondummy_if   ),
     .last_op_if_i                   ( last_op_if             ),
     .abort_op_if_i                  ( abort_op_if            ),
-    .prefetch_valid_if_i            ( prefetch_valid_if      ),
 
     // from IF/ID pipeline
     .if_id_pipe_i                   ( if_id_pipe             ),

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -88,7 +88,7 @@ module cv32e40s_dummy_instr
   // lfsr_cnt will update when the dummy or hint instruction leaves the ID stage
   // cnt_q is updated every time an instruction goes from IF to ID
   //   - reset when a dummy goes from IF to ID
-  //   - incremented when any other instruction (including hint) goes from ID to ID
+  //   - incremented when any other instruction (including hint) goes from IF to ID
   assign dummy_insert_o = (cnt_q > lfsr_cnt) && dummy_en &&              // Limit reached and dummies enabled
                           (first_op_nondummy_i && prefetch_valid_i) &&   // IF stage is on instruction boundary
                           !ptr_in_if_i;                                  // No pointer is in IF

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -89,6 +89,10 @@ module cv32e40s_dummy_instr
   // cnt_q is updated every time an instruction goes from IF to ID
   //   - reset when a dummy goes from IF to ID
   //   - incremented when any other instruction (including hint) goes from IF to ID
+  // Not allowing dummy insertion when the IF stage is handling a pointer.
+  //   Pointers are not counted as instructions in the IF stage, thus instr_issued_i will remain
+  //   low for pointers, causing cnt_q not to reset on dummy insertion.
+  //   If allowing dummies for pointers, pointers would also need to count as instructions.
   assign dummy_insert_o = (cnt_q > lfsr_cnt) && dummy_en &&              // Limit reached and dummies enabled
                           (first_op_nondummy_i && prefetch_valid_i) &&   // IF stage is on instruction boundary
                           !ptr_in_if_i;                                  // No pointer is in IF

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -36,6 +36,9 @@ module cv32e40s_dummy_instr
   (input  logic          clk,
    input  logic          rst_n,
    input  logic          instr_issued_i,
+   input  logic          first_op_nondummy_i,
+   input  logic          ptr_in_if_i,
+   input  logic          prefetch_valid_i,
    input  ctrl_fsm_t     ctrl_fsm_i,
    input  xsecure_ctrl_t xsecure_ctrl_i,
    output logic          dummy_insert_o,
@@ -86,7 +89,9 @@ module cv32e40s_dummy_instr
   // cnt_q is updated every time an instruction goes from IF to ID
   //   - reset when a dummy goes from IF to ID
   //   - incremented when any other instruction (including hint) goes from ID to ID
-  assign dummy_insert_o = (cnt_q > lfsr_cnt) && dummy_en;
+  assign dummy_insert_o = (cnt_q > lfsr_cnt) && dummy_en &&              // Limit reached and dummies enabled
+                          (first_op_nondummy_i && prefetch_valid_i) &&   // IF stage is on instruction boundary
+                          !ptr_in_if_i;                                  // No pointer is in IF
 
   assign cnt_rst        = !dummy_en                          ||      // Reset counter when dummy instructions are disabled
                           (dummy_insert_o && instr_issued_i) ||      // Reset counter when inserting dummy instruction which is propagated to the ID stage

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -676,17 +676,23 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   generate
     if (DUMMY_INSTRUCTIONS) begin : gen_dummy_instr
       logic instr_issued; // Used to count issued instructions between dummy instructions
-      assign instr_issued = if_valid_o && id_ready_i;
+
+      // Count instructions when first_op==1 to not count suboperations of sequences
+      // Do not count pointers as instructions
+      assign instr_issued = if_valid_o && id_ready_i && first_op && !ptr_in_if_o;
 
       cv32e40s_dummy_instr
         dummy_instr_i
-          (.clk            ( clk            ),
-           .rst_n          ( rst_n          ),
-           .instr_issued_i ( instr_issued   ),
-           .ctrl_fsm_i     ( ctrl_fsm_i     ),
-           .xsecure_ctrl_i ( xsecure_ctrl_i ),
-           .dummy_insert_o ( dummy_insert   ),
-           .dummy_instr_o  ( dummy_instr    )
+          (.clk                 ( clk                 ),
+           .rst_n               ( rst_n               ),
+           .instr_issued_i      ( instr_issued        ),
+           .first_op_nondummy_i ( first_op_nondummy_o ),
+           .prefetch_valid_i    ( prefetch_valid      ),
+           .ptr_in_if_i         ( ptr_in_if_o         ),
+           .ctrl_fsm_i          ( ctrl_fsm_i          ),
+           .xsecure_ctrl_i      ( xsecure_ctrl_i      ),
+           .dummy_insert_o      ( dummy_insert        ),
+           .dummy_instr_o       ( dummy_instr         )
            );
 
     end : gen_dummy_instr

--- a/sva/cv32e40s_if_stage_sva.sv
+++ b/sva/cv32e40s_if_stage_sva.sv
@@ -47,7 +47,7 @@ module cv32e40s_if_stage_sva
   input  logic          illegal_c_insn,
   input  logic          instr_compressed,
   input  logic          prefetch_is_tbljmp_ptr,
-  input  logic          first_op_nondummy_o,
+  input  logic          first_op_nondummy,
   input  logic          first_op,
   input  logic          last_op_o,
   input  logic          prefetch_is_clic_ptr,
@@ -128,7 +128,7 @@ module cv32e40s_if_stage_sva
   // Assert that we do not trigger dummy instructions when the sequencer is in the middle of a sequence
   a_no_dummy_mid_sequence :
     assert property (@(posedge clk) disable iff (!rst_n)
-                      !first_op_nondummy_o |-> !dummy_insert)
+                      !first_op_nondummy |-> !dummy_insert)
       else `uvm_error("if_stage", "Dummy instruction inserted mid-sequence")
 
 


### PR DESCRIPTION
- Changed when the counter for issued instructions are reset.
  - Some logic that was used to reset counters (through ctrl_fsm.allow_dummy_instr) was instead moved to factor into dummy_insert_o without resetting the counter)
- Changed how we count instructions (counting when the first operation of an instruction goes from IF to ID, excluding pointers)