### PR TITLE
Merge from CV32E40X

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -188,7 +188,6 @@ module cv32e40s_wrapper
     core_i.if_stage_i cv32e40s_if_stage_sva #(.CLIC(CLIC)) if_stage_sva
     (
       .m_c_obi_instr_if (core_i.m_c_obi_instr_if), // SVA monitor modport cannot connect to a master modport
-      .align_err_i      (core_i.if_stage_i.align_check_i.align_err),
       .*
     );
 

--- a/rtl/cv32e40s_controller_bypass.sv
+++ b/rtl/cv32e40s_controller_bypass.sv
@@ -258,7 +258,7 @@ module cv32e40s_controller_bypass import cv32e40s_pkg::*;
     // Also deassert for trigger match, as with dcsr.timing==0 we do not execute before entering debug mode
     // CLIC pointer fetches go through the pipeline, but no write enables should be active.
     if (if_id_pipe_i.instr.bus_resp.err || !(if_id_pipe_i.instr.mpu_status == MPU_OK) || if_id_pipe_i.trigger_match ||
-        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr || if_id_pipe_i.instr.bus_resp.integrity_err || !(if_id_pipe_i.instr.align_status == ALIGN_OK)) begin
+        if_id_pipe_i.instr_meta.clic_ptr || if_id_pipe_i.instr_meta.mret_ptr || if_id_pipe_i.instr.bus_resp.integrity_err) begin
       ctrl_byp_o.deassert_we = 1'b1;
     end
 

--- a/rtl/cv32e40s_controller_fsm.sv
+++ b/rtl/cv32e40s_controller_fsm.sv
@@ -371,7 +371,6 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   //
   assign exception_in_wb = ((ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ||
                              ex_wb_pipe_i.instr.bus_resp.integrity_err                                                     ||
-                            (ex_wb_pipe_i.instr.align_status != ALIGN_OK)                                                  ||
                              ex_wb_pipe_i.instr.bus_resp.err                                                               ||
                              ex_wb_pipe_i.illegal_insn                                                                     ||
                             (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ||
@@ -389,7 +388,6 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
   //           Bus errors will be converted to NMI as for regular loads.
   assign exception_cause_wb = (ex_wb_pipe_i.instr.mpu_status != MPU_OK)                                                      ? EXC_CAUSE_INSTR_FAULT     :
                                ex_wb_pipe_i.instr.bus_resp.integrity_err                                                     ? EXC_CAUSE_INSTR_INTEGRITY_FAULT :
-                               (ex_wb_pipe_i.instr.align_status != ALIGN_OK)                                                 ? EXC_CAUSE_INSTR_MISALIGNED :
                               ex_wb_pipe_i.instr.bus_resp.err                                                                ? EXC_CAUSE_INSTR_BUS_FAULT :
                               ex_wb_pipe_i.illegal_insn                                                                      ? EXC_CAUSE_ILLEGAL_INSN    :
                               (ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_ecall_insn)                                           ? (priv_lvl_i==PRIV_LVL_M ?
@@ -1085,7 +1083,7 @@ module cv32e40s_controller_fsm import cv32e40s_pkg::*;
               jump_taken_n = 1'b1;
             end
           end else if (clic_ptr_in_id || mret_ptr_in_id) begin
-            if (!(if_id_pipe_i.instr.bus_resp.err || if_id_pipe_i.instr.bus_resp.integrity_err || (if_id_pipe_i.instr.mpu_status != MPU_OK) || (if_id_pipe_i.instr.align_status != ALIGN_OK))) begin
+            if (!(if_id_pipe_i.instr.bus_resp.err || if_id_pipe_i.instr.bus_resp.integrity_err || (if_id_pipe_i.instr.mpu_status != MPU_OK))) begin
               if (!branch_taken_q) begin
                 ctrl_fsm_o.pc_set = 1'b1;
                 ctrl_fsm_o.pc_mux = PC_POINTER;

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -1638,6 +1638,12 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           mcause_n.mpie = mstatus_n.mpie;
           mcause_we = 1'b1;
 
+          // Mret to lower privilege mode clear mintthresh
+          if (priv_lvl_n < PRIV_LVL_M) begin
+            mintthresh_n  = 32'h00000000;
+            mintthresh_we = 1'b1;
+          end
+
           if (ctrl_fsm_i.csr_restore_mret_ptr) begin
             // Clear mcause.minhv if the mret also caused a successful CLIC pointer fetch
             mcause_n.minhv = 1'b0;
@@ -1659,6 +1665,12 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
           // Not really needed, but allows for asserting mstatus_we == mcause_we to check aliasing formally
           mcause_n       = mcause_rdata;
           mcause_we      = 1'b1;
+
+          // Dret to lower privilege mode clear mintthresh
+          if (priv_lvl_n < PRIV_LVL_M) begin
+            mintthresh_n  = 32'h00000000;
+            mintthresh_we = 1'b1;
+          end
         end
 
       end //ctrl_fsm_i.csr_restore_dret

--- a/rtl/cv32e40s_dummy_instr.sv
+++ b/rtl/cv32e40s_dummy_instr.sv
@@ -153,7 +153,6 @@ module cv32e40s_dummy_instr
   assign dummy_instr_o.bus_resp.rdata         = instr;
   assign dummy_instr_o.bus_resp.err           = 1'b0;
   assign dummy_instr_o.mpu_status             = MPU_OK;
-  assign dummy_instr_o.align_status           = ALIGN_OK;
   assign dummy_instr_o.bus_resp.integrity_err = 1'b0;
 
 endmodule : cv32e40s_dummy_instr

--- a/rtl/cv32e40s_ex_stage.sv
+++ b/rtl/cv32e40s_ex_stage.sv
@@ -136,7 +136,6 @@ module cv32e40s_ex_stage import cv32e40s_pkg::*;
                                id_ex_pipe_i.instr.bus_resp.integrity_err     ||
                                id_ex_pipe_i.instr.bus_resp.err               ||
                                (id_ex_pipe_i.instr.mpu_status != MPU_OK)     ||
-                               (id_ex_pipe_i.instr.align_status != ALIGN_OK) ||
                                |id_ex_pipe_i.trigger_match)                  &&
                               id_ex_pipe_i.instr_valid;
 

--- a/rtl/cv32e40s_id_stage.sv
+++ b/rtl/cv32e40s_id_stage.sv
@@ -642,7 +642,6 @@ module cv32e40s_id_stage import cv32e40s_pkg::*;
           id_ex_pipe_o.instr.bus_resp.err           <= if_id_pipe_i.instr.bus_resp.err;
           id_ex_pipe_o.instr.bus_resp.integrity_err <= if_id_pipe_i.instr.bus_resp.integrity_err;
           id_ex_pipe_o.instr.mpu_status             <= if_id_pipe_i.instr.mpu_status;
-          id_ex_pipe_o.instr.align_status           <= if_id_pipe_i.instr.align_status;
         end else begin
           id_ex_pipe_o.instr                <= if_id_pipe_i.instr;
         end

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -144,7 +144,6 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   logic                       prefetch_trans_valid;
   logic                       prefetch_trans_ready;
   logic [31:0]                prefetch_trans_addr;
-  logic                       prefetch_trans_ptr;
   inst_resp_t                 prefetch_inst_resp;
   logic                       prefetch_one_txn_pend_n;
   logic [ALBUF_CNT_WIDTH-1:0] prefetch_outstnd_cnt_q;
@@ -158,14 +157,6 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   logic              dummy_insert;
   inst_resp_t        dummy_instr;
-  logic              alcheck_resp_valid;
-  inst_resp_t        alcheck_resp;
-  logic              alcheck_trans_valid;
-  logic              alcheck_trans_ready;
-  obi_inst_req_t     alcheck_trans;
-
-  logic              align_check_en;
-  logic              address_misaligned;
 
   // Local instr_valid
   logic              instr_valid;
@@ -203,7 +194,9 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
       PC_BOOT:       branch_addr_n = {boot_addr_i[31:2], 2'b0};
       PC_JUMP:       branch_addr_n = jump_target_id_i;
       PC_BRANCH:     branch_addr_n = branch_target_ex_i;
-      PC_MRET:       branch_addr_n = mepc_i;                                                      // PC is restored when returning from IRQ/exception
+      // An mret that restarts a CLIC pointer fetch must make sure the address is aligned to XLEN/8.
+      // Clearing branch_addr_n[1] when an mepc is used as part of CLIC pointer fetch.
+      PC_MRET:       branch_addr_n = {mepc_i[31:2], (mepc_i[1] & !ctrl_fsm_i.pc_set_clicv), mepc_i[0]}; // PC is restored when returning from IRQ/exception
       PC_DRET:       branch_addr_n = dpc_i;
       PC_WB_PLUS4:   branch_addr_n = ctrl_fsm_i.pipe_pc;                                          // Jump to next instruction forces prefetch buffer reload
       PC_TRAP_EXC:   branch_addr_n = {mtvec_addr_i, 7'h0};                                        // All the exceptions go to base address
@@ -253,7 +246,6 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .trans_valid_o            ( prefetch_trans_valid        ),
     .trans_ready_i            ( prefetch_trans_ready        ),
     .trans_addr_o             ( prefetch_trans_addr         ),
-    .trans_ptr_o              ( prefetch_trans_ptr          ),
 
     .resp_valid_i             ( prefetch_resp_valid         ),
     .resp_i                   ( prefetch_inst_resp          ),
@@ -286,7 +278,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .IF_STAGE             ( 1                       ),
     .CORE_REQ_TYPE        ( obi_inst_req_t          ),
     .CORE_RESP_TYPE       ( inst_resp_t             ),
-    .BUS_RESP_TYPE        ( inst_resp_t             ),
+    .BUS_RESP_TYPE        ( obi_inst_resp_t         ),
     .PMA_NUM_REGIONS      ( PMA_NUM_REGIONS         ),
     .PMA_CFG              ( PMA_CFG                 ),
     .PMP_GRANULARITY      ( PMP_GRANULARITY         ),
@@ -315,47 +307,13 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
     .core_resp_valid_o    ( prefetch_resp_valid         ),
     .core_resp_o          ( prefetch_inst_resp          ),
 
-    .bus_trans_valid_o    ( alcheck_trans_valid         ),
-    .bus_trans_ready_i    ( alcheck_trans_ready         ),
-    .bus_trans_o          ( alcheck_trans               ),
-    .bus_resp_valid_i     ( alcheck_resp_valid          ),
-    .bus_resp_i           ( alcheck_resp                )
+    .bus_trans_valid_o    ( bus_trans_valid             ),
+    .bus_trans_ready_i    ( bus_trans_ready             ),
+    .bus_trans_o          ( bus_trans                   ),
+    .bus_resp_valid_i     ( bus_resp_valid              ),
+    .bus_resp_i           ( bus_resp                    )
   );
 
-
-  assign align_check_en = prefetch_trans_ptr;
-  assign address_misaligned = |prefetch_trans_addr[1:0];
-
-  cv32e40s_align_check
-  #(
-    .IF_STAGE             ( 1                    ),
-    .CORE_RESP_TYPE       ( inst_resp_t          ),
-    .BUS_RESP_TYPE        ( obi_inst_resp_t      ),
-    .CORE_REQ_TYPE        ( obi_inst_req_t       )
-  )
-  align_check_i
-  (
-    .clk                  ( clk                     ),
-    .rst_n                ( rst_n                   ),
-    .align_check_en_i     ( align_check_en          ),
-    .misaligned_access_i  ( address_misaligned      ),
-
-    .core_one_txn_pend_n  ( prefetch_one_txn_pend_n ),
-    .core_align_err_wait_i( 1'b1                    ),
-    .core_align_err_o     (                         ), // Unconnected on purpose
-
-    .core_trans_valid_i   ( alcheck_trans_valid     ),
-    .core_trans_ready_o   ( alcheck_trans_ready     ),
-    .core_trans_i         ( alcheck_trans           ),
-    .core_resp_valid_o    ( alcheck_resp_valid      ),
-    .core_resp_o          ( alcheck_resp            ),
-
-    .bus_trans_valid_o    ( bus_trans_valid         ),
-    .bus_trans_ready_i    ( bus_trans_ready         ),
-    .bus_trans_o          ( bus_trans               ),
-    .bus_resp_valid_i     ( bus_resp_valid          ),
-    .bus_resp_i           ( bus_resp                )
-  );
 
   //////////////////////////////////////////////////////////////////////////////
   // OBI interface
@@ -484,7 +442,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   // Set flag to indicate that instruction/sequence will be aborted due to known exceptions or trigger match
   assign abort_op_o = dummy_insert ? 1'b0 :
                       (instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK) ||
-                      (instr_decompressed.bus_resp.integrity_err) || (instr_decompressed.align_status != ALIGN_OK) || |trigger_match_i);
+                      (instr_decompressed.bus_resp.integrity_err) || |trigger_match_i);
 
   assign prefetch_valid_o = prefetch_valid;
 
@@ -552,7 +510,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
           // For mret pointers, the pointer address is only needed downstream if the pointer fetch fails.
           // If the pointer fetch is successful, the address of the mret (i.e. the previous PC) is needed.
           if(prefetch_is_mret_ptr ?
-             (instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK) || (instr_decompressed.align_status != ALIGN_OK)) :
+             (instr_decompressed.bus_resp.err || (instr_decompressed.mpu_status != MPU_OK)) :
              1'b1) begin
             if_id_pipe_o.pc                    <= pc_if_o;
           end
@@ -578,7 +536,6 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
           if_id_pipe_o.instr.bus_resp.err           <= instr_decompressed.bus_resp.err;
           if_id_pipe_o.instr.mpu_status             <= instr_decompressed.mpu_status;
           if_id_pipe_o.instr.bus_resp.integrity_err <= instr_decompressed.bus_resp.integrity_err;
-          if_id_pipe_o.instr.align_status           <= instr_decompressed.align_status;
         end else begin
           // Regular instruction, update the whole instr field
           // Dummy instructions replace instruction word with a random instruction word

--- a/rtl/cv32e40s_mpu.sv
+++ b/rtl/cv32e40s_mpu.sv
@@ -188,9 +188,8 @@ module cv32e40s_mpu import cv32e40s_pkg::*;
 
   // Forward transaction response towards core
   assign core_resp_valid_o      = bus_resp_valid_i || mpu_err_trans_valid;
-  assign core_resp_o.bus_resp   = bus_resp_i.bus_resp;
   assign core_resp_o.mpu_status = mpu_status;
-  assign core_resp_o.align_status = bus_resp_i.align_status;
+
 
   // Report MPU errors to the core immediately
   assign core_mpu_err_o = mpu_err;
@@ -249,17 +248,20 @@ module cv32e40s_mpu import cv32e40s_pkg::*;
   // Tie to 1'b0 if this MPU is instantiatied in the IF stage
   generate
     if (IF_STAGE) begin: mpu_if
-      assign instr_fetch_access = 1'b1;
-      assign load_access        = 1'b0;
-      assign core_trans_we      = 1'b0;
+      assign instr_fetch_access     = 1'b1;
+      assign load_access            = 1'b0;
+      assign core_trans_we          = 1'b0;
+      assign core_resp_o.bus_resp   = bus_resp_i;
       assign pmp_req_type       = PMP_ACC_EXEC;
     end
     else begin: mpu_lsu
-      assign instr_fetch_access    = 1'b0;
-      assign load_access           = !core_trans_i.we;
-      assign core_trans_we         = core_trans_i.we;
+      assign instr_fetch_access       = 1'b0;
+      assign load_access              = !core_trans_i.we;
+      assign core_trans_we            = core_trans_i.we;
+      assign core_resp_o.wpt_match    = '0; // Will be set by upstream wpt-module within load_store_unit
+      assign core_resp_o.align_status = bus_resp_i.align_status;
+      assign core_resp_o.bus_resp     = bus_resp_i.bus_resp;
       assign pmp_req_type          = core_trans_we ? PMP_ACC_WRITE : PMP_ACC_READ;
-      assign core_resp_o.wpt_match = '0; // Will be set by upstream wpt-module within load_store_unit
     end
   endgenerate
 

--- a/rtl/cv32e40s_prefetch_unit.sv
+++ b/rtl/cv32e40s_prefetch_unit.sv
@@ -54,7 +54,6 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
   output logic        trans_valid_o,
   input  logic        trans_ready_i,
   output logic [31:0] trans_addr_o,
-  output logic        trans_ptr_o,
 
   input  logic        resp_valid_i,
   input  inst_resp_t  resp_i,
@@ -106,8 +105,7 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
     .fetch_priv_lvl_access_o  ( fetch_priv_lvl_resp  ),
     .trans_valid_o            ( trans_valid_o        ),
     .trans_ready_i            ( trans_ready_i        ),
-    .trans_addr_o             ( trans_addr_o         ),
-    .trans_ptr_o              ( trans_ptr_o          )
+    .trans_addr_o             ( trans_addr_o         )
   );
 
 

--- a/rtl/cv32e40s_prefetcher.sv
+++ b/rtl/cv32e40s_prefetcher.sv
@@ -58,8 +58,7 @@ module cv32e40s_prefetcher import cv32e40s_pkg::*;
   // Transaction request interface
   output logic                     trans_valid_o,           // Transaction request valid (to bus interface adapter)
   input  logic                     trans_ready_i,           // Transaction request ready (transaction gets accepted when trans_valid_o and trans_ready_i are both 1)
-  output logic [31:0]              trans_addr_o,            // Transaction address (only valid when trans_valid_o = 1). No stability requirements.
-  output logic                     trans_ptr_o              // Transaction is fetching a pointer
+  output logic [31:0]              trans_addr_o             // Transaction address (only valid when trans_valid_o = 1). No stability requirements.
 );
 
 
@@ -78,8 +77,6 @@ module cv32e40s_prefetcher import cv32e40s_pkg::*;
   // Alignment buffer controls number of outstanding transactions
   // and will always be ready to accept responses.
   assign trans_valid_o = fetch_valid_i;
-
-  assign trans_ptr_o = fetch_ptr_access_o;
 
   assign fetch_ready_o = trans_valid_o && trans_ready_i;
 

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -998,7 +998,6 @@ typedef enum logic[3:0] {
 } pc_mux_e;
 
 // Exception Cause
-parameter EXC_CAUSE_INSTR_MISALIGNED      = 11'h00;
 parameter EXC_CAUSE_INSTR_FAULT           = 11'h01;
 parameter EXC_CAUSE_ILLEGAL_INSN          = 11'h02;
 parameter EXC_CAUSE_BREAKPOINT            = 11'h03;
@@ -1212,7 +1211,6 @@ typedef struct packed {
 typedef struct packed {
  obi_inst_resp_t             bus_resp;
  mpu_status_e                mpu_status;
- align_status_e              align_status;   // Alignment status (for mret pointers)
 } inst_resp_t;
 
 // Reset value for the inst_resp_t type
@@ -1220,8 +1218,7 @@ parameter inst_resp_t INST_RESP_RESET_VAL = '{
   // Setting rdata[1:0] to 2'b11 to easily assert that all
   // instructions in ID are uncompressed
   bus_resp     : '{rdata: 32'h3, err: 1'b0, rchk: 5'b0,integrity_err: 1'b0, integrity: 1'b0},
-  mpu_status   : MPU_OK,
-  align_status : ALIGN_OK
+  mpu_status   : MPU_OK
 };
 
 // Reset value for the obi_inst_req_t type

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -347,7 +347,7 @@ module cv32e40s_controller_fsm_sva
   a_mret_mmode :
     assert property (@(posedge clk) disable iff (!rst_n)
                       // Disregard higher priority exceptions and trigger match
-                      !(((ex_wb_pipe_i.instr.mpu_status != MPU_OK) || (ex_wb_pipe_i.instr.align_status != ALIGN_OK) || ex_wb_pipe_i.instr.bus_resp.err || trigger_match_in_wb) && ex_wb_pipe_i.instr_valid) &&
+                      !(((ex_wb_pipe_i.instr.mpu_status != MPU_OK) || ex_wb_pipe_i.instr.bus_resp.err || trigger_match_in_wb) && ex_wb_pipe_i.instr_valid) &&
                       !(ex_wb_pipe_i.instr_meta.clic_ptr || ex_wb_pipe_i.instr_meta.mret_ptr) && !ctrl_fsm_o.debug_mode &&
                       // Check for mret in instruction word and user mode
                       ((ex_wb_pipe_i.instr.bus_resp.rdata == 32'h30200073) && ex_wb_pipe_i.instr_valid && (priv_lvl_i == PRIV_LVL_M))
@@ -637,16 +637,6 @@ if (CLIC) begin
                   |=>
                   $stable(mintstatus_i))
     else `uvm_error("controller", "mintstatus changed after taking an NMI")
-
-  // The only possible cause for a instruction misaligned exception is an mret pointer.
-  a_mret_ptr_exception:
-  assert property (@(posedge clk) disable iff (!rst_n)
-                  (exception_cause_wb == EXC_CAUSE_INSTR_MISALIGNED) &&
-                  exception_in_wb
-                  |->
-                  mret_ptr_in_wb)
-
-    else `uvm_error("controller", "Instruction address misaligned exception without mret pointer.")
 
 end else begin // CLIC
   // Check that CLIC related signals are inactive when CLIC is not configured.

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -268,7 +268,7 @@ always_ff @(posedge clk , negedge rst_ni)
         expected_ebrk_mepc <= ex_wb_pipe.pc;
       end
 
-      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) && (ex_wb_pipe.instr.align_status == ALIGN_OK) && !irq_ack && !pending_debug &&
+      if (!first_instr_err_found && (ex_wb_pipe.instr.mpu_status == MPU_OK) &&!irq_ack && !pending_debug &&
          !(ctrl_fsm.pc_mux == PC_TRAP_NMI) &&
           ex_wb_pipe.instr_valid && ex_wb_pipe.instr.bus_resp.err && !ctrl_debug_mode_n ) begin
         first_instr_err_found   <= 1'b1;

--- a/sva/cv32e40s_if_stage_sva.sv
+++ b/sva/cv32e40s_if_stage_sva.sv
@@ -53,8 +53,6 @@ module cv32e40s_if_stage_sva
   input  logic          prefetch_is_clic_ptr,
   input  logic          prefetch_is_mret_ptr,
   input  logic [31:0]   branch_addr_n,
-  input  logic          align_err_i,
-  input  logic          alcheck_trans_valid,
   input  logic          ptr_in_if_o
 );
 
@@ -186,31 +184,11 @@ module cv32e40s_if_stage_sva
     a_aligned_mret_ptr:
       assert property (@(posedge clk) disable iff (!rst_n)
                       (ctrl_fsm_i.pc_set_clicv) &&
-                      (ctrl_fsm_i.pc_mux == PC_MRET) &&
-                      (branch_addr_n[1:0] != 2'b00)
+                      (ctrl_fsm_i.pc_mux == PC_MRET)
                       |->
-                      align_err_i
-                      )
-          else `uvm_error("if_stage", "Misaligned mret pointer not flagged with error")
+                      (branch_addr_n[1:0] == 2'b00))
+          else `uvm_error("if_stage", "Misaligned mret pointer")
 
-    // Aligned errors may only happen for mret pointers that are not otherwise blocked by the MPU
-    a_aligned_err_mret_ptr:
-      assert property (@(posedge clk) disable iff (!rst_n)
-                      align_err_i &&            // Alignment error flagged
-                      alcheck_trans_valid       // Transaction not blocked by MPU
-                      |->
-                      ((ctrl_fsm_i.pc_set_clicv) &&     // We have a pc_set for an mret pointer this cycle
-                      (ctrl_fsm_i.pc_mux == PC_MRET))
-                      or
-                      prefetch_is_mret_ptr)             // Or the trans_valid comes after the pc_set and an mret pointer is flagged
-          else `uvm_error("if_stage", "Alignment error withouth mret pointer")
-  end else begin
-
-    // Without CLIC support there shall never be an aligned error in the IF stage.
-    a_no_align_err:
-      assert property (@(posedge clk) disable iff (!rst_n)
-                      !align_err_i)
-          else `uvm_error("if_stage", "Alignment error withouth CLIC support.")
   end
 
   // Tablejump pointer shall always be aligned


### PR DESCRIPTION
Includes updates to the latest CLIC specification.

Note that an update was needed in the pc_check module to accomodate for the forced XLEN/8 alignment of mret pointers.