### PR TITLE
Fix for issue #473. 

### DIFF
--- a/rtl/cv32e40s_instr_obi_interface.sv
+++ b/rtl/cv32e40s_instr_obi_interface.sv
@@ -214,31 +214,31 @@ module cv32e40s_instr_obi_interface import cv32e40s_pkg::*;
    )
   integrity_fifo_i
   (
-    .clk                (clk                              ),
-    .rst_n              (rst_n                            ),
+    .clk                (clk                                    ),
+    .rst_n              (rst_n                                  ),
 
     // gnt parity error
-    .gntpar_err_i       (gntpar_err                       ),
+    .gntpar_err_i       (gntpar_err                             ),
 
     // Transaction inputs
-    .trans_integrity_i  (trans_i.integrity                ),
-    .trans_we_i         (1'b0                             ),
+    .trans_integrity_i  (m_c_obi_instr_if.req_payload.integrity ),
+    .trans_we_i         (1'b0                                   ),
 
     // Xsecure
-    .xsecure_ctrl_i     (xsecure_ctrl_i                   ),
+    .xsecure_ctrl_i     (xsecure_ctrl_i                         ),
 
     // Response phase properties
-    .gntpar_err_resp_o  (gntpar_err_resp                  ),
-    .integrity_resp_o   (integrity_resp                   ),
-    .rchk_err_resp_o    (rchk_err_resp                    ),
+    .gntpar_err_resp_o  (gntpar_err_resp                        ),
+    .integrity_resp_o   (integrity_resp                         ),
+    .rchk_err_resp_o    (rchk_err_resp                          ),
 
-    .protocol_err_o     (protocol_err                     ),
+    .protocol_err_o     (protocol_err                           ),
 
     // OBI interface
-    .obi_req_i          (m_c_obi_instr_if.s_req.req       ),
-    .obi_gnt_i          (m_c_obi_instr_if.s_gnt.gnt       ),
-    .obi_rvalid_i       (m_c_obi_instr_if.s_rvalid.rvalid ),
-    .obi_resp_i         (resp_o                           )
+    .obi_req_i          (m_c_obi_instr_if.s_req.req             ),
+    .obi_gnt_i          (m_c_obi_instr_if.s_gnt.gnt             ),
+    .obi_rvalid_i       (m_c_obi_instr_if.s_rvalid.rvalid       ),
+    .obi_resp_i         (resp_o                                 )
   );
 
 

--- a/sva/cv32e40s_alignment_buffer_sva.sv
+++ b/sva/cv32e40s_alignment_buffer_sva.sv
@@ -49,7 +49,9 @@ module cv32e40s_alignment_buffer_sva
    input logic [1:0]               rptr2,
    input logic                     pop_q,
    input privlvl_t                 instr_priv_lvl_o,
-   input logic                     ptr_fetch_accepted_q
+   input logic                     ptr_fetch_accepted_q,
+   input logic                     rchk_err_q0,
+   input logic                     rchk_err_q1
    );
 
 
@@ -331,5 +333,14 @@ a_no_outstanding_instr_valid:
   else
     `uvm_error("Alignment buffer SVA", "No instr_valid when expected")
 
+  a_no_rchk_err_q0:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    1'b1 |-> !rchk_err_q0)
+          else `uvm_error("core", "rchk_err_q0 shall be zero.")
+
+  a_no_rchk_err_q1:
+    assert property (@(posedge clk) disable iff (!rst_n)
+                    1'b1 |-> !rchk_err_q1)
+          else `uvm_error("core", "rchk_err_q1 shall be zero.")
 endmodule // cv32e40s_alignment_buffer_sva
 

--- a/sva/cv32e40s_core_sva.sv
+++ b/sva/cv32e40s_core_sva.sv
@@ -619,6 +619,11 @@ end
                     1'b1 |-> !pc_err_if)
           else `uvm_error("core", "pc_err_if shall be zero.")
 
+  a_no_major_exception_err:
+    assert property (@(posedge clk) disable iff (!rst_ni)
+                    1'b1 |-> !ctrl_fsm.exception_alert_major)
+          else `uvm_error("core", "ctrl_fsm.exception_alert_major shall be zero.")
+
   // There should be no parity error on output signals
   logic instr_reqpar_expected;
   logic data_reqpar_expected;

--- a/sva/cv32e40s_instr_obi_interface_sva.sv
+++ b/sva/cv32e40s_instr_obi_interface_sva.sv
@@ -33,7 +33,6 @@ module cv32e40s_instr_obi_interface_sva
   input logic           gntpar_err,
   input logic           gntpar_err_q,
   input obi_inst_resp_t resp_o,
-  input obi_inst_req_t  trans_i,
   input logic           gntpar_err_resp
 );
 
@@ -67,7 +66,7 @@ always_comb begin
                                {gnt_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_ERR} :
                                {gnt_fifo_q[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
 
-        int_fifo_n = trans_i.integrity ?
+        int_fifo_n = m_c_obi_instr_if.req_payload.integrity ?
                                {int_fifo_q[MAX_OUTSTND_TXN-2:0], INT} :
                                {int_fifo_q[MAX_OUTSTND_TXN-2:0], NOINT};
       end
@@ -85,7 +84,7 @@ always_comb begin
                                {gnt_fifo_tmp[MAX_OUTSTND_TXN-2:0], GNT_NOERR};
 
         int_fifo_tmp[oldest_txn] = INT_NONE;
-        int_fifo_n = trans_i.integrity ?
+        int_fifo_n = m_c_obi_instr_if.req_payload.integrity ?
                                 {int_fifo_tmp[MAX_OUTSTND_TXN-2:0], INT} :
                                 {int_fifo_tmp[MAX_OUTSTND_TXN-2:0], NOINT};
       end


### PR DESCRIPTION
In addition to the reported issue this bug could also cause false major alerts.

Integrity fifo in instruction obi used signals with wrong timing. Used trans_i.integrity instead of the actual signals used with req-timing.