### PR TITLE
Version 2 RTD configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Configuration file for ReadTheDocs, used to render the CV32E40S
+# User Manual to https://docs.openhwgroup.org/projects/cv32e40s-user-manual.
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.1
+
+version: 2
+
+#build:
+#  os: "ubuntu-20.04"
+#  tools:
+#    python: "3.9"
+
+# Build from the docs/user_manual/source directory with Sphinx
+sphinx:
+  configuration: docs/user_manual/source/conf.py
+
+# Explicitly set the Python requirements
+python:
+  install:
+    - requirements: docs/user_manual/requirements.txt


### PR DESCRIPTION
The Read the Docs build system will start requiring a v2 configuration file (.readthedocs.yaml) starting on September 25, 2023.