### PR TITLE
Uncomment assertion in cv32e40s_div_sva

### DIFF
--- a/sva/cv32e40s_div_sva.sv
+++ b/sva/cv32e40s_div_sva.sv
@@ -49,14 +49,11 @@ module cv32e40s_div_sva
 
   // Assert that valid_o is set in the 34th cycle 
   // cycle_count==33 in the 34th cycle because the counter is reset in the cycle after division is accepted.
-  //TODO: lowThis only applies to the 40S, data_ind_timing_i only exists there.
-  //      Keep commented until 40S fork, and then delete from 40X
-  /*
   a_data_ind_timing :
     assert property (@(posedge clk) disable iff (!rst_n)
                      ($rose(valid_o) && data_ind_timing_i |-> cycle_count == 33))
       else `uvm_error("div", "Data independent cycle count failed")
-  */
+
   a_ready_o :  
     assert property (@(posedge clk) disable iff (!rst_n)
                      (valid_o && ready_i |-> ready_o))


### PR DESCRIPTION
Assertion passing.
Corresponding assertion in e40x will be removed (since e40xdoes not support data independent timing).