### PR TITLE
IF stage todo removal

### DIFF
--- a/rtl/cv32e40s_alignment_buffer.sv
+++ b/rtl/cv32e40s_alignment_buffer.sv
@@ -24,7 +24,8 @@
 module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
 #(
   parameter int unsigned ALBUF_DEPTH     = 3,
-  parameter int unsigned ALBUF_CNT_WIDTH = $clog2(ALBUF_DEPTH)
+  parameter int unsigned ALBUF_CNT_WIDTH = $clog2(ALBUF_DEPTH),
+  parameter int unsigned MAX_OUTSTANDING = 2
 )
 (
   input  logic           clk,
@@ -136,7 +137,7 @@ module cv32e40s_alignment_buffer import cv32e40s_pkg::*;
   // For CLIC vector loads we want to stop prefetching between an accepted pointer load and
   // the next pc_set (to the target address).
   assign fetch_valid_o = (ctrl_fsm_i.instr_req )                                     &&
-                         (outstanding_cnt_q < 2)                                     &&
+                         (outstanding_cnt_q < MAX_OUTSTANDING)                       &&
                          !(ptr_fetch_accepted_q && !ctrl_fsm_i.pc_set)               && // No fetch until next pc_set after accepted pointer fetches
                          (((instr_cnt_q - pop_q) == 'd0)                             ||
                          ((instr_cnt_q - pop_q) == 'd1 && outstanding_cnt_q == ALBUF_CNT_WIDTH'(0)) ||

--- a/rtl/cv32e40s_if_stage.sv
+++ b/rtl/cv32e40s_if_stage.sv
@@ -120,6 +120,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   // Otherwise the resulting concatenated address will be less than 32 bits.
   localparam int unsigned CLIC_MUX_WIDTH = (CLIC_ID_WIDTH < 4) ? 4 : CLIC_ID_WIDTH;
 
+  localparam int unsigned MAX_OUTSTANDING = 2;
+
   logic              if_ready;
 
   // prefetch buffer related signals
@@ -225,7 +227,8 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   #(
       .CLIC            (CLIC),
       .ALBUF_DEPTH     (ALBUF_DEPTH),
-      .ALBUF_CNT_WIDTH (ALBUF_CNT_WIDTH)
+      .ALBUF_CNT_WIDTH (ALBUF_CNT_WIDTH),
+      .MAX_OUTSTANDING (MAX_OUTSTANDING)
   )
   prefetch_unit_i
   (
@@ -267,7 +270,6 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
   // MPU
   //////////////////////////////////////////////////////////////////////////////
 
-  // TODO: The prot bits are currently not checked for correctness anywhere
   assign core_trans.addr      = prefetch_trans_addr;
   assign core_trans.dbg       = ctrl_fsm_i.debug_mode_if;
   assign core_trans.prot[0]   = 1'b0;                        // Transfers from IF stage are instruction transfers
@@ -325,7 +327,7 @@ module cv32e40s_if_stage import cv32e40s_pkg::*;
 
   cv32e40s_instr_obi_interface
   #(
-    .MAX_OUTSTANDING (2) // todo: hook up to parameter
+    .MAX_OUTSTANDING (MAX_OUTSTANDING)
   )
   instruction_obi_i
   (

--- a/rtl/cv32e40s_prefetch_unit.sv
+++ b/rtl/cv32e40s_prefetch_unit.sv
@@ -30,7 +30,8 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
 #(
     parameter bit CLIC                     = 1'b0,
     parameter int unsigned ALBUF_DEPTH     = 3,
-    parameter int unsigned ALBUF_CNT_WIDTH = $clog2(ALBUF_DEPTH)
+    parameter int unsigned ALBUF_CNT_WIDTH = $clog2(ALBUF_DEPTH),
+    parameter int unsigned MAX_OUTSTANDING = 2
 )
 (
   input  logic        clk,
@@ -112,7 +113,8 @@ module cv32e40s_prefetch_unit import cv32e40s_pkg::*;
   cv32e40s_alignment_buffer
   #(
     .ALBUF_DEPTH(ALBUF_DEPTH),
-    .ALBUF_CNT_WIDTH(ALBUF_CNT_WIDTH)
+    .ALBUF_CNT_WIDTH(ALBUF_CNT_WIDTH),
+    .MAX_OUTSTANDING(MAX_OUTSTANDING)
   )
   alignment_buffer_i
   (


### PR DESCRIPTION
- Removed IF stage todo about checking prot bits - already covered by core-v-verif.
- Added localparam to set max number of outstanding transactions in the prefetcher. The only supported value is 2 for now.

SEC clean.