### PR TITLE
Flushing pipeline on writes to mstateen0.

### DIFF
--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -556,6 +556,14 @@ endgenerate
                        .wb_valid_i           (core_i.wb_stage_i.wb_valid_o                           ),
                        .exception_in_wb_i    (core_i.controller_i.controller_fsm_i.exception_in_wb   ),
                        .pending_sync_debug_i (core_i.controller_i.controller_fsm_i.pending_sync_debug),
+                       .csr_addr_id_i        (core_i.id_stage_i.operand_b[11:0]),
+                       .csr_en_id_i          (core_i.id_stage_i.csr_en),
+                       .instr_valid_id_i     (core_i.id_stage_i.instr_valid),
+                       .csr_raddr_ex_i       (core_i.cs_registers_i.csr_raddr),
+                       .csr_waddr_wb_i       (core_i.cs_registers_i.csr_waddr),
+                       .csr_we_wb_i          (core_i.cs_registers_i.csr_we_int),
+                       .priv_lvl_id_i        (core_i.if_id_pipe.priv_lvl),
+                       .csr_illegal_i        (core_i.cs_registers_i.csr_illegal_o),
                        .*);
 
   bind cv32e40s_instr_obi_interface :

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -373,6 +373,9 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   // Detect JVT writes (requires pipeline flush)
   logic                         jvt_wr_in_wb;
 
+  // Detect mstateen0 writes (requires pipeline flush)
+  logic                         mstateen0_wr_in_wb;
+
   logic                         mscratch_rd_error;
   logic                         mstatus_rd_error;
   logic                         mtvec_rd_error;
@@ -2216,7 +2219,10 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
   // Detect when a JVT write is in WB
   assign jvt_wr_in_wb = csr_wr_in_wb && (csr_waddr == CSR_JVT);
 
-  assign csr_wr_in_wb_flush_o = xsecure_csr_wr_in_wb || pmp_csr_wr_in_wb || jvt_wr_in_wb;
+  // Detect when a mstateen0 write is in WB
+  assign mstateen0_wr_in_wb = csr_wr_in_wb && (csr_waddr == CSR_MSTATEEN0);
+
+  assign csr_wr_in_wb_flush_o = xsecure_csr_wr_in_wb || pmp_csr_wr_in_wb || jvt_wr_in_wb || mstateen0_wr_in_wb;
 
   if (USER) begin : privlvl_user
   // Privilege level register


### PR DESCRIPTION
Not a real requirement, as the hazard is resolved as a byproduct og other stalls but it is much easier to understand.