### PR TITLE
Merge from cv32e40x

### DIFF
--- a/bhv/cv32e40s_rvfi.sv
+++ b/bhv/cv32e40s_rvfi.sv
@@ -81,6 +81,7 @@ module cv32e40s_rvfi
    input logic                                lsu_pma_err_ex_i,
    input logic                                lsu_pma_err_atomic_ex_i,
    input pma_cfg_t                            lsu_pma_cfg_ex_i,
+   input logic                                lsu_atomic_align_err_ex_i,
    input logic                                lsu_misaligned_ex_i,
    input obi_data_req_t                       buffer_trans_ex_i,
    input logic                                buffer_trans_valid_ex_i,
@@ -625,6 +626,7 @@ module cv32e40s_rvfi
   logic [31:0]       pc_wb_past;
   logic [4:0]        rd_addr_wb_past;
   logic [31:0]       rd_wdata_wb_past;
+  privlvl_t          priv_lvl_wb_past;
 
 
   //Propagating from EX stage
@@ -658,6 +660,12 @@ module cv32e40s_rvfi
   rvfi_csr_map_t rvfi_csr_rmask;
   rvfi_csr_map_t rvfi_csr_wdata;
   rvfi_csr_map_t rvfi_csr_wmask;
+
+  // CSR inputs for handling mret pointers with mret in WB_PAST stage
+  rvfi_csr_map_t rvfi_csr_rdata_wb_past;
+  rvfi_csr_map_t rvfi_csr_wdata_wb_past;
+  rvfi_csr_map_t rvfi_csr_rmask_wb_past;
+  rvfi_csr_map_t rvfi_csr_wmask_wb_past;
 
   // Reads from autonomous registers propagate from EX stage
   rvfi_auto_csr_map_t ex_csr_rdata;
@@ -852,7 +860,7 @@ module cv32e40s_rvfi
       // Indicate synchronous (non-debug entry) trap
       rvfi_trap_next.exception       = 1'b1;
       rvfi_trap_next.exception_cause = ctrl_fsm_i.csr_cause.exception_code[5:0]; // All synchronous exceptions fit in lower 6 bits
-      rvfi_trap_next.clicptr         = clic_ptr_wb_i;
+      rvfi_trap_next.clicptr         = clic_ptr_wb_i || mret_ptr_wb_i;
 
       // Separate exception causes with the same exception cause code
       case (ctrl_fsm_i.csr_cause.exception_code)
@@ -1223,8 +1231,12 @@ module cv32e40s_rvfi
           ex_mem_trans_2 <= lsu_data_trans;
         end
 
-        mem_err [STAGE_WB]  = lsu_pma_err_misaligned_ex    ? MEM_ERR_IO_ALIGN          : // Non-natrually aligned access to !main
+        // Capture cause of LSU exception for the cases that can have multiple reasons for an exception
+        // These are currently load and store access faults trigger by misaligned access to i/o regions,
+        // atomic accesses to regions not enabled for atomics or accesses blocked by PMP.
+        mem_err [STAGE_WB]  = lsu_pma_err_misaligned_ex    ? MEM_ERR_IO_ALIGN          : // Non-naturally aligned access to !main
                               lsu_pma_err_atomic_ex        ? MEM_ERR_ATOMIC            : // Any atomic to non-atomic PMA region
+                              lsu_atomic_align_err_ex_i    ? MEM_ERR_ATOMIC_MISALIGN   : // Misaligned atomic
                                                              MEM_ERR_PMP;                // PMP error
 
         // Read autonomuos CSRs from EX perspective
@@ -1254,7 +1266,7 @@ module cv32e40s_rvfi
         rvfi_rd_wdata   <= mret_ptr_wb ? rd_wdata_wb_past : rd_wdata_wb;
 
         // Read/Write CSRs
-        // No mret pointer muxing, CSR updates for mret with CLIC pointer happens when the pointer reachces WB.
+        // Muxing values for mret/mret pointers happens on the inputs (*_d) below
         rvfi_csr_rdata  <= rvfi_csr_rdata_d;
         rvfi_csr_rmask  <= rvfi_csr_rmask_d;
         rvfi_csr_wdata  <= rvfi_csr_wdata_d;
@@ -1274,7 +1286,7 @@ module cv32e40s_rvfi
         rvfi_instr_memtype <= mret_ptr_wb ? instr_req[STAGE_WB_PAST].memtype : instr_req[STAGE_WB].memtype;
         rvfi_instr_dbg     <= mret_ptr_wb ? instr_req[STAGE_WB_PAST].dbg     : instr_req[STAGE_WB].dbg;
 
-        rvfi_mode      <= priv_lvl_i;
+        rvfi_mode      <= mret_ptr_wb ? priv_lvl_wb_past : priv_lvl_i;
 
         rvfi_dbg       <= mret_ptr_wb ? debug_cause[STAGE_WB_PAST] : debug_cause[STAGE_WB];
         rvfi_dbg_mode  <= mret_ptr_wb ? debug_mode [STAGE_WB_PAST] : debug_mode[STAGE_WB];
@@ -1301,6 +1313,14 @@ module cv32e40s_rvfi
         instr_rdata_wb_past         <= instr_rdata_wb_i;
         rd_addr_wb_past             <= rd_addr_wb;
         rd_wdata_wb_past            <= rd_wdata_wb;
+
+        // Remember CSR reads/writes for instruction in WB
+        rvfi_csr_rdata_wb_past <= rvfi_csr_rdata_d;
+        rvfi_csr_wdata_wb_past <= rvfi_csr_wdata_d;
+        rvfi_csr_rmask_wb_past <= rvfi_csr_rmask_d;
+        rvfi_csr_wmask_wb_past <= rvfi_csr_wmask_d;
+
+        priv_lvl_wb_past       <= priv_lvl_i;
 
         // Clear rvfi_mem and rvfi_gpr on first op
         if (first_op_wb_i) begin
@@ -1486,10 +1506,14 @@ module cv32e40s_rvfi
   assign rvfi_csr_wmask_d.jvt                = csr_jvt_we_i ? '1 : '0;
 
   // Machine trap setup
-  assign rvfi_csr_rdata_d.mstatus            = csr_mstatus_q_i;
+  // If an mret pointer is in WB, capture CSR rdata as seen by the mret instruction.
+  // Write mask/data are either from the mret (if pointer fetch is successful) or the pointer fetch  (if it generates an exception)
+  assign rvfi_csr_rdata_d.mstatus            = mret_ptr_wb ? rvfi_csr_rdata_wb_past.mstatus : csr_mstatus_q_i;
   assign rvfi_csr_rmask_d.mstatus            = '1;
-  assign rvfi_csr_wdata_d.mstatus            = csr_mstatus_n_i;
-  assign rvfi_csr_wmask_d.mstatus            = csr_mstatus_we_i ? '1 : '0;
+  assign rvfi_csr_wdata_d.mstatus            = mret_ptr_wb ? (csr_mstatus_we_i ? csr_mstatus_n_i : rvfi_csr_wdata_wb_past.mstatus)
+                                                           : csr_mstatus_n_i;
+  assign rvfi_csr_wmask_d.mstatus            = mret_ptr_wb ? (csr_mstatus_we_i ? '1 : rvfi_csr_wmask_wb_past.mstatus)
+                                                           : (csr_mstatus_we_i ? '1 : '0);
 
   assign rvfi_csr_rdata_d.mstatush           = csr_mstatush_q_i;
   assign rvfi_csr_rmask_d.mstatush           = '1;
@@ -1541,10 +1565,14 @@ module cv32e40s_rvfi
   assign rvfi_csr_wdata_d.mepc               = csr_mepc_n_i;
   assign rvfi_csr_wmask_d.mepc               = csr_mepc_we_i ? '1 : '0;
 
-  assign rvfi_csr_rdata_d.mcause             = csr_mcause_q_i;
+  // If an mret pointer is in WB, capture CSR rdata as seen by the mret instruction.
+  // Write mask/data are either from the mret (if pointer fetch is successful) or the pointer fetch  (if it generates an exception)
+  assign rvfi_csr_rdata_d.mcause             = mret_ptr_wb ? rvfi_csr_rdata_wb_past.mcause : csr_mcause_q_i;
   assign rvfi_csr_rmask_d.mcause             = '1;
-  assign rvfi_csr_wdata_d.mcause             = csr_mcause_n_i;
-  assign rvfi_csr_wmask_d.mcause             = csr_mcause_we_i ? '1 : '0;
+  assign rvfi_csr_wdata_d.mcause             = mret_ptr_wb ? (csr_mcause_we_i ? csr_mcause_n_i : rvfi_csr_wdata_wb_past.mcause)
+                                                           : csr_mcause_n_i;
+  assign rvfi_csr_wmask_d.mcause             = mret_ptr_wb ? (csr_mcause_we_i ? '1 : rvfi_csr_wmask_wb_past.mcause)
+                                                           : (csr_mcause_we_i ? '1 : '0);
 
   assign rvfi_csr_rdata_d.mtval              = '0;
   assign rvfi_csr_rmask_d.mtval              = '1;
@@ -1566,15 +1594,22 @@ module cv32e40s_rvfi
   assign rvfi_csr_wdata_d.mnxti              = csr_mnxti_n_i;
   assign rvfi_csr_wmask_d.mnxti              = csr_mnxti_we_i ? '1 : '0;
 
-  assign rvfi_csr_rdata_d.mintstatus         = csr_mintstatus_q_i;
+  // If an mret pointer is in WB, capture CSR rdata as seen by the mret instruction.
+  // Write mask/data are either from the mret (if pointer fetch is successful) or the pointer fetch  (if it generates an exception)
+  assign rvfi_csr_rdata_d.mintstatus         = mret_ptr_wb ? rvfi_csr_rdata_wb_past.mintstatus : csr_mintstatus_q_i;
   assign rvfi_csr_rmask_d.mintstatus         = '1;
-  assign rvfi_csr_wdata_d.mintstatus         = csr_mintstatus_n_i;
-  assign rvfi_csr_wmask_d.mintstatus         = csr_mintstatus_we_i ? '1 : '0;
-
-  assign rvfi_csr_rdata_d.mintthresh         = csr_mintthresh_q_i;
+  assign rvfi_csr_wdata_d.mintstatus         = mret_ptr_wb ? (csr_mintstatus_we_i ? csr_mintstatus_n_i : rvfi_csr_wdata_wb_past.mintstatus)
+                                                           : csr_mintstatus_n_i;
+  assign rvfi_csr_wmask_d.mintstatus         = mret_ptr_wb ? (csr_mintstatus_we_i ? '1 : rvfi_csr_wmask_wb_past.mintstatus)
+                                                           : (csr_mintstatus_we_i ? '1 : '0);
+  // If an mret pointer is in WB, capture CSR rdata as seen by the mret instruction.
+  // Write mask/data are either from the mret (if pointer fetch is successful) or the pointer fetch  (if it generates an exception)
+  assign rvfi_csr_rdata_d.mintthresh         = mret_ptr_wb ? rvfi_csr_rdata_wb_past.mintthresh : csr_mintthresh_q_i;
   assign rvfi_csr_rmask_d.mintthresh         = '1;
-  assign rvfi_csr_wdata_d.mintthresh         = csr_mintthresh_n_i;
-  assign rvfi_csr_wmask_d.mintthresh         = csr_mintthresh_we_i ? '1 : '0;
+  assign rvfi_csr_wdata_d.mintthresh         = mret_ptr_wb ? (csr_mintthresh_we_i ? csr_mintthresh_n_i : rvfi_csr_wdata_wb_past.mintthresh)
+                                                           : csr_mintthresh_n_i;
+  assign rvfi_csr_wmask_d.mintthresh         = mret_ptr_wb ? (csr_mintthresh_we_i ? '1 : rvfi_csr_wmask_wb_past.mintthresh)
+                                                           : (csr_mintthresh_we_i ? '1 : '0);
 
   assign rvfi_csr_rdata_d.mscratchcsw        = csr_mscratchcsw_q_i;
   assign rvfi_csr_rmask_d.mscratchcsw        = csr_mscratchcsw_in_wb_i ? '1 : '0;

--- a/bhv/cv32e40s_wrapper.sv
+++ b/bhv/cv32e40s_wrapper.sv
@@ -454,6 +454,8 @@ if (CLIC) begin : clic_asserts
                                  .ctrl_fsm_cs             (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
                                  .ctrl_fsm                (core_i.ctrl_fsm),
                                  .dcsr                    (core_i.dcsr),
+                                 .ex_wb_pipe_i            (core_i.ex_wb_pipe),
+                                 .last_op_wb_i            (core_i.last_op_wb),
                                  .*);
 end
 endgenerate
@@ -692,6 +694,7 @@ endgenerate
          .lsu_pma_err_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_err_o                       ),
          .lsu_pma_err_atomic_ex_i  ( 1'b0                        /* Atomics not implemented in cv32e40s*/ ),
          .lsu_pma_cfg_ex_i         ( core_i.load_store_unit_i.mpu_i.pma_i.pma_cfg                         ),
+         .lsu_atomic_align_err_ex_i( 1'b0                        /* Atomics not implemented in cv32e40s*/ ),
          .lsu_misaligned_ex_i      ( core_i.load_store_unit_i.misaligned_access                           ),
          .buffer_trans_ex_i        ( core_i.load_store_unit_i.buffer_trans                                ),
          .buffer_trans_valid_ex_i  ( core_i.load_store_unit_i.buffer_trans_valid                          ),

--- a/bhv/include/cv32e40s_rvfi_pkg.sv
+++ b/bhv/include/cv32e40s_rvfi_pkg.sv
@@ -32,7 +32,8 @@ package cv32e40s_rvfi_pkg;
   typedef enum logic [1:0] { // Memory error types
     MEM_ERR_PMP      = 2'h2,
     MEM_ERR_ATOMIC   = 2'h1,
-    MEM_ERR_IO_ALIGN = 2'h0
+    MEM_ERR_IO_ALIGN = 2'h0,
+    MEM_ERR_ATOMIC_MISALIGN = 2'h3
   } mem_err_t;
 
   typedef struct packed { // Autonomously updated CSRs

--- a/rtl/cv32e40s_cs_registers.sv
+++ b/rtl/cv32e40s_cs_registers.sv
@@ -1649,8 +1649,7 @@ module cv32e40s_cs_registers import cv32e40s_pkg::*;
         end
       end //ctrl_fsm_i.csr_save_cause
 
-      ctrl_fsm_i.csr_restore_mret,
-      ctrl_fsm_i.csr_restore_mret_ptr: begin // MRET
+      ctrl_fsm_i.csr_restore_mret: begin // MRET
         priv_lvl_n     = privlvl_t'(mstatus_rdata.mpp);
         priv_lvl_we    = 1'b1;
 

--- a/rtl/include/cv32e40s_pkg.sv
+++ b/rtl/include/cv32e40s_pkg.sv
@@ -1485,7 +1485,6 @@ typedef struct packed {
   logic [31:0] pipe_pc;             // PC from pipeline
   mcause_t     csr_cause;           // CSR cause (saves to mcause CSR)
   logic        csr_restore_mret;    // Restore CSR due to mret
-  logic        csr_restore_mret_ptr; // Restore CSR due to mret followed by CLIC
   logic        csr_restore_dret;    // Restore CSR due to dret
   logic        csr_save_cause;      // Update CSRs
   logic        pending_nmi;         // An NMI is pending (for dcsr.nmip)

--- a/sva/cv32e40s_clic_int_controller_sva.sv
+++ b/sva/cv32e40s_clic_int_controller_sva.sv
@@ -50,7 +50,10 @@ module cv32e40s_clic_int_controller_sva
    input ctrl_state_e ctrl_fsm_cs,
 
    input ctrl_fsm_t   ctrl_fsm,
-   input dcsr_t       dcsr
+   input dcsr_t       dcsr,
+
+   input ex_wb_pipe_t ex_wb_pipe_i,
+   input logic        last_op_wb_i
 );
 
   // Check that a pending interrupt is taken as soon as possible after being enabled
@@ -59,7 +62,11 @@ module cv32e40s_clic_int_controller_sva
     ( !irq_req_ctrl_o
        ##1
        irq_req_ctrl_o && $stable(clic_irq_q) && $stable(clic_irq_level_q) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie))
-       |-> (ctrl_pending_interrupt && ctrl_interrupt_allowed));
+       |->
+       ((ctrl_pending_interrupt && ctrl_interrupt_allowed) || // Interrupt pendinding and allowed to be taken
+        ($past(ex_wb_pipe_i.instr_valid) && $past(ex_wb_pipe_i.sys_en) && $past(ex_wb_pipe_i.sys_mret_insn) && !$past(last_op_wb_i)) &&
+        (ctrl_pending_interrupt && !ctrl_interrupt_allowed)) // Interrupts enabled by mret mid-sequence, not allowed to be taken
+    );
   endproperty;
 
   a_clic_enable: assert property(p_clic_enable)
@@ -72,7 +79,8 @@ module cv32e40s_clic_int_controller_sva
       ##1                        // Next cycle
       irq_req_ctrl_o && $stable(clic_irq_q) && $stable(clic_irq_level_q) && !(ctrl_fsm.debug_mode || (dcsr.step && !dcsr.stepie)) && // Interrupt pending but irq inputs are unchanged
       (ctrl_fsm_cs != DEBUG_TAKEN) &&  // Make sure we are not handling a debug entry already (could be a single stepped mret enabling interrupts for instance)
-      !(ctrl_pending_nmi || ctrl_pending_async_debug)   // No pending events with higher priority than interrupts are taking place
+      !(ctrl_pending_nmi || ctrl_pending_async_debug) &&  // No pending events with higher priority than interrupts are taking place
+      ctrl_interrupt_allowed                              // and interrupts are allowed (mret which restarts pointer fetch may reenable interrupts before the sequence is finished)
       |->
       ctrl_fsm.irq_ack  // We must take the interrupt if enabled (mret or CSR write) and no NMI or external debug is pending
     );

--- a/sva/cv32e40s_controller_fsm_sva.sv
+++ b/sva/cv32e40s_controller_fsm_sva.sv
@@ -417,6 +417,8 @@ module cv32e40s_controller_fsm_sva
     assert property (@(posedge clk) disable iff (!rst_n)
                       // Disregard higher priority exceptions and trigger match
                       !(((ex_wb_pipe_i.instr.mpu_status != MPU_OK) || ex_wb_pipe_i.instr.bus_resp.err || trigger_match_in_wb) && ex_wb_pipe_i.instr_valid) &&
+                      // Disregard mret pointers, these can look like mret instructions (may only happen when mret restarts pointer fetch in user mode)
+                      !(ex_wb_pipe_i.instr_meta.mret_ptr) &&
                       // Check for mret in instruction word and user mode
                       ((ex_wb_pipe_i.instr.bus_resp.rdata == 32'h30200073) && ex_wb_pipe_i.instr_valid && (priv_lvl_i == PRIV_LVL_U))
                       |-> (exception_in_wb && (exception_cause_wb == EXC_CAUSE_ILLEGAL_INSN) && !(ex_wb_pipe_i.sys_en && ex_wb_pipe_i.sys_mret_insn)))


### PR DESCRIPTION
Includes fix for mret + mcause.minhv and the needed CSR updates for that scenario.

SEC clean when mcause.minhv is assumed to be zero.