### PR TITLE
Fix undefined signals on instr_req_o

### DIFF
--- a/rtl/cv32e40s_lsu_response_filter.sv
+++ b/rtl/cv32e40s_lsu_response_filter.sv
@@ -114,10 +114,10 @@ module cv32e40s_lsu_response_filter
   ///////////////////////////////////////////
 
   assign core_count_up   = core_trans_accepted;
-  assign core_count_down = resp_valid_o;
-
+  assign core_count_down = resp_valid_o && (core_cnt_q > 2'b00); // check to make sure we aren't going out of bounds;
+                                                                 //     checks for count_up are performed elsewhere
   assign bus_count_up    = bus_trans_accepted;
-  assign bus_count_down  = resp_valid_i;
+  assign bus_count_down  = resp_valid_i && (bus_cnt_q > 2'b00);
 
   always_comb begin
     core_next_cnt = core_cnt_q;

--- a/rtl/cv32e40s_lsu_response_filter.sv
+++ b/rtl/cv32e40s_lsu_response_filter.sv
@@ -82,8 +82,8 @@ module cv32e40s_lsu_response_filter
   logic                  core_resp_is_bufferable;
 
   // Shift register containing bufferable cofiguration of outstanding transfers
-  outstanding_t [DEPTH:0]        outstanding_q; // Using 1-DEPTH entries for outstanding xfers, index 0 is tied low
-  outstanding_t [DEPTH:0]        outstanding_next;
+  outstanding_t [DEPTH+1:0]        outstanding_q; // Using 1-DEPTH entries for outstanding xfers, index 0 is tied low
+  outstanding_t [DEPTH+1:0]        outstanding_next;
 
   assign busy_o              = ( bus_cnt_q != '0) || valid_i;
 
@@ -114,10 +114,10 @@ module cv32e40s_lsu_response_filter
   ///////////////////////////////////////////
 
   assign core_count_up   = core_trans_accepted;
-  assign core_count_down = resp_valid_o && (core_cnt_q > 2'b00); // check to make sure we aren't going out of bounds;
-                                                                 //     checks for count_up are performed elsewhere
+  assign core_count_down = resp_valid_o;
+
   assign bus_count_up    = bus_trans_accepted;
-  assign bus_count_down  = resp_valid_i && (bus_cnt_q > 2'b00);
+  assign bus_count_down  = resp_valid_i;
 
   always_comb begin
     core_next_cnt = core_cnt_q;

--- a/rtl/cv32e40s_obi_integrity_fifo.sv
+++ b/rtl/cv32e40s_obi_integrity_fifo.sv
@@ -94,8 +94,10 @@ module cv32e40s_obi_integrity_fifo import cv32e40s_pkg::*;
   // Outstanding transactions counter
   // Used for tracking parity errors and integrity attribute
   /////////////////////////////////////////////////////////////
-  assign count_up = obi_req_i && obi_gnt_i;  // Increment upon accepted transfer request
-  assign count_down = obi_rvalid_i;                       // Decrement upon accepted transfer response
+  assign count_up = obi_req_i && obi_gnt_i &&                       // Increment upon accepted transfer request
+                        (count_down || cnt_q != MAX_OUTSTANDING);   // Handle overflow; counter either needs to not change or stay < 3 
+  assign count_down = obi_rvalid_i && cnt_q != 2'b00 &&             // Decrement upon accepted transfer response
+                        (count_down || cnt_q != MAX_OUTSTANDING);   // Handle overflow; counter either needs to not change or stay > 0
 
   always_comb begin
     case ({count_up, count_down})

--- a/rtl/cv32e40s_obi_integrity_fifo.sv
+++ b/rtl/cv32e40s_obi_integrity_fifo.sv
@@ -74,7 +74,7 @@ module cv32e40s_obi_integrity_fifo import cv32e40s_pkg::*;
 
   // FIFO is 1 bit deeper than the maximum value of bus_cnt_i
   // Index 0 is tied low to enable direct use of bus_cnt_i to pick correct FIFO index.
-  fifo_t [MAX_OUTSTANDING:0] fifo_q;
+  fifo_t [MAX_OUTSTANDING+1:0] fifo_q;
   fifo_t fifo_input;
 
   // Parity and rchk error signals
@@ -94,10 +94,8 @@ module cv32e40s_obi_integrity_fifo import cv32e40s_pkg::*;
   // Outstanding transactions counter
   // Used for tracking parity errors and integrity attribute
   /////////////////////////////////////////////////////////////
-  assign count_up = obi_req_i && obi_gnt_i &&                       // Increment upon accepted transfer request
-                        (count_down || cnt_q != MAX_OUTSTANDING);   // Handle overflow; counter either needs to not change or stay < 3 
-  assign count_down = obi_rvalid_i && cnt_q != 2'b00 &&             // Decrement upon accepted transfer response
-                        (count_down || cnt_q != MAX_OUTSTANDING);   // Handle overflow; counter either needs to not change or stay > 0
+  assign count_up = obi_req_i && obi_gnt_i;  // Increment upon accepted transfer request
+  assign count_down = obi_rvalid_i;                       // Decrement upon accepted transfer response
 
   always_comb begin
     case ({count_up, count_down})


### PR DESCRIPTION
Fixes this issue: https://github.com/openhwgroup/cv32e40s/issues/530
Arrays/buffers in cv32e40s_obi_integrity_fifo.sv and cv32e40s_lsu_response_filter.sv did not have proper bound checking (two bit index with a default buffer size of three, meaning that in cases of 2'b11 an undefined signal would occur).
Specifically, the LSU response filter only checked increments, not decrements, and the integrity FIFO did not ever check bounds.
As discussed, this resulted in X's appearing on the instr_req_o and instr_reqpar_o lines, among others. This occurred frequently during fuzz testing.
My fix uses logic similar to the increment bound checking in the LSU response filter on the other three cases (LSU response filter decrement, integrity FIFO increment, and integrity FIFO decrement).